### PR TITLE
Add jumpDistance to actor rollData

### DIFF
--- a/allActors/jump.mjs
+++ b/allActors/jump.mjs
@@ -1,0 +1,55 @@
+//make jump distance available in actor.getRollData();
+import { MODULE } from "../scripts/constants.mjs";
+
+export default {
+    _onLibWrapperReady,
+    _onDAESetup
+}
+
+function _onLibWrapperReady() {
+    libWrapper.register(MODULE.ID, "dnd5e.documents.Actor5e.prototype.getRollData", function (wrapped, ...args) {
+        const data = wrapped(...args);
+
+        //rollData.talia.jumpDistance
+        return foundry.utils.mergeObject(data, {
+            talia: {
+                jumpDistance: calculateJumpDistance(data),
+            }
+        });
+    }, "WRAPPER");
+}
+
+//add flags to DAE
+function _onDAESetup() {
+    const fields = [];
+    fields.push("flags.talia-custom.jumpDist.bonus");
+    fields.push("flags.talia-custom.jumpDist.countDoubled");
+    fields.push("flags.talia-custom.jumpDist.countHalved");
+    window.DAE.addAutoFields(fields);
+}
+
+
+function calculateJumpDistance(rollData) {
+    const acr = Math.max(foundry.utils.getProperty(rollData, "skills.acr.total") ?? 0, 0);
+    const ath = Math.max(foundry.utils.getProperty(rollData, "skills.ath.total") ?? 0, 0);
+
+    //the distance is based off either Athletics or Acrobatics skill, whichever one is higher
+    const higherSkill = acr > ath ? acr : ath;
+
+    //(Base (+0) = 5ft; +5ft per +2) (i.e. Athletics 8 = 25ft)
+    //round to next lower even number if odd
+    const workingSkillValue = higherSkill - (higherSkill % 2);
+    const baseDistance =  5 + ((workingSkillValue / 2) * 5);
+
+    const distAdd = foundry.utils.getProperty(rollData, "flags.talia-custom.jumpDist.bonus") ?? 0;
+    const distDouble = foundry.utils.getProperty(rollData, "flags.talia-custom.jumpDist.countDoubled") ?? 0;
+    const distHalf = foundry.utils.getProperty(rollData, "flags.talia-custom.jumpDist.countHalved") ?? 0;
+
+    //caps the multiplier at 0.25 and 4.
+    const distMult = Math.clamped(Math.pow(2, distDouble - distHalf), 0.25, 4);
+
+    const calculatedDistance = (baseDistance + distAdd) * distMult;
+    //round that to the nearest interval of 5
+    return Math.round(calculatedDistance / 5) * 5;
+}
+

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+# 29/06/2024
+## Added
+- Jump distance in feet is now accessible within each actor's rollData under `actor.getRollData().talia.jumpDistance`. The number will always be a multiple of 5 (or 0).
+- Three new Active Effects flags have been added:
+    - `"flags.talia-custom.jumpDist.bonus"` | ADD | NUMBER  
+        A number of ft to be added to the actor's maximum jump distance, can be negative.
+    - `"flags.talia-custom.jumpDist.countDoubled"` | ADD | NUMBER  
+        A number of times the sum of base distance + bonus should be doubled
+    - `"flags.talia-custom.jumpDist.countHalved"` | ADD | NUMBER  
+        A number of times the sum of base distance + bonus should be halved
+
+
 # 28/06/2024
 ## Added
 - Beast Spirit: Bear

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -3,11 +3,6 @@ import { setupSocket } from "./socket.mjs";
 import { TaliaCustomAPI } from "./api.mjs";
 
 
-
-//import { setup_spellbookLich } from "../fearghas/items/spellbookLich.mjs";
-//import { Spellbooks } from "../fearghas/items/spellbooks.mjs";
-
-
 import beastSpirits from "../aviana/items/beastSpirits.mjs";
 import wildMagic from "../wildMagic/wildMagic.mjs";
 import cooking from "../shalkoc/cooking.mjs";
@@ -15,10 +10,15 @@ import chef from "../shalkoc/Feats/chef.mjs";
 import spellscribing from "../spellscribing/spellscribing.mjs";
 import spellbooks from "../fearghas/items/spellbooks.mjs";
 import spellbookLich from "../fearghas/items/spellbookLich.mjs";
+import jump from "../allActors/jump.mjs";
 
 
 Hooks.once("socketlib.ready", () => {
     setupSocket();
+});
+
+Hooks.once("libWrapper.Ready", () => {
+    jump._onLibWrapperReady();
 });
 
 Hooks.once("init", () => {
@@ -38,6 +38,12 @@ Hooks.once("setup", () => {
     spellscribing._onSetup();
     spellbooks._onSetup();
     spellbookLich._onSetup();
+    
 
     console.log(`${MODULE.ID} set up.`);
+});
+
+//add flags to DAE
+Hooks.once("DAE.setupComplete", () => {
+    jump._onDAESetup();
 });


### PR DESCRIPTION
Fixes #28

Jump distance in feet is now accessible within each actor's rollData under `actor.getRollData().talia.jumpDistance`. The number will always be a multiple of 5 (or 0).

Three new Active Effects flags have been added:
    - `"flags.talia-custom.jumpDist.bonus"` | ADD | NUMBER  
        A number of ft to be added to the actor's maximum jump distance, can be negative.
    - `"flags.talia-custom.jumpDist.countDoubled"` | ADD | NUMBER  
        A number of times the sum of base distance + bonus should be doubled
    - `"flags.talia-custom.jumpDist.countHalved"` | ADD | NUMBER  
        A number of times the sum of base distance + bonus should be halved