### PR TITLE
Added api function rollTableGrantItems() to _foundryHelpers

### DIFF
--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -15,6 +15,7 @@ import gratefulFeyCharm from "../aviana/items/gratefulFeyCharm.mjs";
 import commonActions from "../allActors/commonActions.mjs";
 import shove from "../allActors/shove.mjs";
 import contraptionsCrafting from "../plex/contraptionsCrafting/contraptionsCrafting.mjs";
+import { helpersToApi } from "./_foundryHelpers.mjs";
 
 
 Hooks.once("socketlib.ready", () => {
@@ -46,6 +47,7 @@ Hooks.once("setup", () => {
     spellbookLich._onSetup();
     gratefulFeyCharm._onSetup();
     contraptionsCrafting._onSetup();
+    helpersToApi._onSetup();
 
     console.log(`${MODULE.ID} set up.`);
 });


### PR DESCRIPTION
This api function rolls a number of items from a table and grant them to an actor directly.
When doing so it also 'stacks' items fo the same name, by adding up the quantities instead of granting duplicates of the item. 