### PR TITLE
Prevent Actor Sheet Closing After WMS & Auto-Maximize After Template Placement

### DIFF
--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -16,6 +16,7 @@ import commonActions from "../allActors/commonActions.mjs";
 import shove from "../allActors/shove.mjs";
 import contraptionsCrafting from "../plex/contraptionsCrafting/contraptionsCrafting.mjs";
 import { helpersToApi } from "./_foundryHelpers.mjs";
+import templateOpenCharSheet from "../systemChanges/templateOpenCharSheet.mjs";
 
 
 Hooks.once("socketlib.ready", () => {
@@ -24,6 +25,7 @@ Hooks.once("socketlib.ready", () => {
 
 Hooks.once("libWrapper.Ready", () => {
     jump._onLibWrapperReady();
+    templateOpenCharSheet._onLibWrapperReady();
 });
 
 Hooks.once("init", () => {

--- a/spellscribing/scribingUi.mjs
+++ b/spellscribing/scribingUi.mjs
@@ -125,12 +125,6 @@ export class ScribingUI extends FormApplication {
             //reload all data since this returned true;
             this.onScribing_recheckData();
             return this.render();
-        } else if(result === "surge") {
-            //closes the window if a surge was caused
-            await this.close();
-            //close the character sheet too
-            //maybe minimise instead?
-            await this.actor.sheet.close();
         }
     }  
 

--- a/systemChanges/templateOpenCharSheet.mjs
+++ b/systemChanges/templateOpenCharSheet.mjs
@@ -1,0 +1,27 @@
+import { MODULE } from "../scripts/constants.mjs";
+
+/**
+ * Prevents the actor sheet from being maximised after an ability template has been placed.
+ */
+export default {
+    _onLibWrapperReady() {
+        libWrapper.register(MODULE.ID, 'dnd5e.applications.actor.ActorSheet5e.prototype.maximize', 
+            async function(wrapped, ...args) {
+                if(game.user.getFlag(MODULE.ID, 'preventActorSheetMax')) return;
+                else return wrapped(...args);
+            }, "MIXED"
+        );
+
+        libWrapper.register(MODULE.ID, 'dnd5e.canvas.AbilityTemplate.prototype._finishPlacement', 
+            async function(wrapped, ...args) {
+                //set flag on user to disable maximising the sheet
+                await game.user.setFlag(MODULE.ID, 'preventActorSheetMax', true);
+                //call the original
+                const ret = await wrapped(...args);
+                //unset flag on user to enable maximising the sheet again
+                await game.user.unsetFlag(MODULE.ID, 'preventActorSheetMax')
+                return ret;
+            }, "WRAPPER"
+        );
+    }
+}


### PR DESCRIPTION
- Fixed an issue where the actor sheet would close after a WMS triggered during spellscribing.
- Stopped the actor sheet from auto-maximizing when you place an ability template.

fixes #67