### PR TITLE
Plex level 10 & Talia Actors Compendium

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
     - Fearghas -> level 10
     - Aviana -> level 10
     - Shalkoc -> level 10
+    - Plex -> level 10
 
 - Features
     - Spirit of the Wolf
@@ -88,11 +89,24 @@
 
     - Hold Monster
     - Ray of Frost
+    - Shape Water
+    - Telekinesis
+    - Animate Objects
+
+- Summonable creatures
+    - Animated Object (Tiny)
+    - Animated Object (Small)
+    - Animated Object (Medium)
+    - Animated Object (Large)
+    - Animated Object (Huge)
 
 - Items
     - Ring of Protection +2
     - Circlet of Wisdom
     - Glasses of True Seeing
+
+- Compendium "Talia Actors" (key="talia-actors")
+    Used to store custom creature templates for summoning and polymorphing.
 
 ## Fixed
 - Fearghas' Spellbook now correctly grants spells when equipped again.

--- a/module.json
+++ b/module.json
@@ -69,6 +69,17 @@
       "label": "Talia Macros",
       "path": "packs/taliaMacros",
       "type": "Macro",
+      "system": "dnd5e",
+      "ownership": {
+        "PLAYER": "OBSERVER",
+        "ASSISTANT": "OWNER"
+      }
+    },
+    {
+      "name": "talia-actors",
+      "label": "Talia Actors",
+      "path": "packs/talia-actors",
+      "type": "Actor",
       "ownership": {
         "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
@@ -78,8 +89,14 @@
   ],
   "flags": {
     "hotReload": {
-      "extensions": ["css", "hbs"],
-      "paths": ["templates", "styles"]
+      "extensions": [
+        "css",
+        "hbs"
+      ],
+      "paths": [
+        "templates",
+        "styles"
+      ]
     }
   }
 }


### PR DESCRIPTION
- Plex level 10 (closes)
- Compendium "Talia Actors" (key="talia-actors")
    Used to store custom creature tempates for summoning and polymorphing
- Spells
    - Shape Water
    - Telekinesis
    - Animate Objects