### PR TITLE
vrazzak lair heist items and some fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,42 @@
+# 0.4.0 - 2024/07/30
+## Added
+- Spells
+    - Bloody Rites
+    - Blood Barrier
+    - Inflict Wounds
+    - Gentle Repose
+    - Nondetection
+    - Circle of Death
+
+- Items
+    - Strionic Resonator
+    - Drunken Brawler's Dancing Shoes
+    - Sneaky Spellshite's Amulet
+    - Unholy Grimoire of Blood
+
+    - <details><summary>Spell Gems and Scrolls from Vrazzak's Lair (added to the storage chest in the cabin)</summary>  
+
+        - 2x Activated: Circle of Death - 6th
+        - 4x Activated: Circle of Death - 9th
+        - 4x Activated: Inflict Wounds - 4th
+        - 9x Activated: Nondetection - 3rd
+        - 7x Triggered: Greater Restoration - 9th
+        - 3x Spell Scroll: Gentle Repose
+    </details>
+
+- Learned spells from scrolls (Fearghas)
+    - Teleport
+    - Wind Walk
+    - Greater Invisibility
+
+- Rules for triggered abilities
+
+## Fixed
+- Spells that are granted by items while those items are equipped and/or attuned can no longer be scribed.
+- Spellbooks now check for attunement as well when adding/removing spells.
+- Created spell gems now show their spell level in the title.
+- Fixed console log spam during spellscribing.
+
 # 0.3.0 - 2024/07/23
 ## Added
 - Levels

--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,7 @@
 - Spellbooks now check for attunement as well when adding/removing spells.
 - Created spell gems now show their spell level in the title.
 - Fixed console log spam during spellscribing.
+- Added missing spells to Plex (Animate Objects and Telekinesis)
 
 # 0.3.0 - 2024/07/23
 ## Added

--- a/spellscribing/SpellGem.mjs
+++ b/spellscribing/SpellGem.mjs
@@ -26,8 +26,16 @@ export async function createSpellGem(actor, chosenArgs) {
 
 function getChanges(actor, chosenArgs) {
     const rollData = actor.getRollData();
+
+    //get spell level level for name (0th, 1st, 2nd,...9th)
+    const titleSpellLevelString = 
+        chosenArgs.selectedSpellSlotLevel === 1 ? " - 1st" :
+        chosenArgs.selectedSpellSlotLevel === 2 ? " - 2nd" :
+        chosenArgs.selectedSpellSlotLevel === 3 ? " - 3rd" :
+        ` - ${chosenArgs.selectedSpellSlotLevel}th`;
+
     //general changes first
-    const name = chosenArgs.isTrigger ? `Triggered: ${chosenArgs.chosenSpell.name}` : `Activated: ${chosenArgs.chosenSpell.name}`;
+    const name = chosenArgs.isTrigger ? `Triggered: ${chosenArgs.chosenSpell.name}${titleSpellLevelString}` : `Activated: ${chosenArgs.chosenSpell.name}${titleSpellLevelString}`;
     const changes = {
         "flags.tidy5e-sheet.section": "Spell Gem",
         "img": chosenArgs.chosenGem.img,

--- a/spellscribing/scribingUi.mjs
+++ b/spellscribing/scribingUi.mjs
@@ -50,17 +50,7 @@ export class ScribingUI extends FormApplication {
     }
 
     render(force=false, options = {}) {
-        /*
-        //add clause for when the user doesn't have any gemstones
-        //I don't need this if the user can't scribe at all without gems
-        if(!this.gemstonesSorted.length) {
-            ui.notifications.warn("You don't have any gemstones to scribe.");
-            if(!this.rendered) return;
-            setTimeout(() => this.close(), 0);
-        }
-        */
         this._updateButtonText();
-        console.log(this);
         return super.render(force, options);
     }
 
@@ -73,7 +63,6 @@ export class ScribingUI extends FormApplication {
             this.chosenData.addedButtonText = "";
         }
     }
-
 
     async _onDrop(event) {
         const data = TextEditor.getDragEventData(event);
@@ -93,6 +82,12 @@ export class ScribingUI extends FormApplication {
         //check preparation mode
         if (["atwill", "innate", "pact"].includes(droppedItem.system?.preparation?.mode)) {
             ui.notifications.warn(`Spells of type: "${droppedItem.system.preparation.mode}" are not supported.`);
+            return;
+        }
+
+        //disallow spells that have been granted by other items
+        if(droppedItem.flags?.["talia-custom"]?.grantedByUuid) {
+            ui.notifications.warn("You cannot scribe spells that have been granted by items.");
             return;
         }
 
@@ -116,10 +111,7 @@ export class ScribingUI extends FormApplication {
             isTrigger: this.chosenData.isTrigger,
             triggerConditions: this.chosenData.triggerConditions || ""
         }
-        console.log("_handleScribing: chosenArgs ", chosenArgs);
-
         const result = await spellscribing(this.actor, chosenArgs);
-        console.log({result: result});
 
         if(result === true) {
             //reload all data since this returned true;
@@ -129,8 +121,6 @@ export class ScribingUI extends FormApplication {
     }  
 
     async getData() {
-
-
         const data = {
             spell: {
                 name: "Drop your spell here",


### PR DESCRIPTION
## Added
- Spells
    - Bloody Rites
    - Blood Barrier
    - Inflict Wounds
    - Gentle Repose
    - Nondetection
    - Circle of Death

- Items
    - Strionic Resonator
    - Drunken Brawler's Dancing Shoes
    - Sneaky Spellshite's Amulet
    - Unholy Grimoire of Blood

    - <details><summary>Spell Gems and Scrolls from Vrazzak's Lair (added to the storage chest in the cabin)</summary>  

        - 2x Activated: Circle of Death - 6th
        - 4x Activated: Circle of Death - 9th
        - 4x Activated: Inflict Wounds - 4th
        - 9x Activated: Nondetection - 3rd
        - 7x Triggered: Greater Restoration - 9th
        - 3x Spell Scroll: Gentle Repose
    </details>

- Learned spells from scrolls (Fearghas)
    - Teleport
    - Wind Walk
    - Greater Invisibility

- Rules for triggered abilities

## Fixed
- Spells that are granted by items while those items are equipped and/or attuned can no longer be scribed.
- Spellbooks now check for attunement as well when adding/removing spells.
- Created spell gems now show their spell level in the title.
- Fixed console log spam during spellscribing.
- closes #92