### PR TITLE
0.5.0

### DIFF
--- a/allActors/changesToConditions.mjs
+++ b/allActors/changesToConditions.mjs
@@ -1,0 +1,109 @@
+/*
+    add changes to all the various status condition types
+*/
+
+export default {
+    _onInit() {
+        addChangesToStatusEffects();
+    }
+}
+
+
+function addChangesToStatusEffects() {
+    // keys are id and values are changes arrays
+    const changesList = {
+        dead: [],   //no changes
+        bleeding: [],   //no changes
+        blinded: [
+            {key: "flags.midi-qol.disadvantage.attack.all", mode: 0, value: "1", priority: 1},
+            {key: "flags.adv-reminder.message.ability.check.all", mode: 0, value: "A blinded creature can't see and automatically fails any ability check that requires sight.", priority: 1},
+        ],
+        burrowing: [],  //no changes
+        charmed: [],    //no changes
+        concentrating: [],  //no changes
+        cursed: [],     //no changes
+        deafened: [
+            {key: "flags.adv-reminder.message.ability.check.all", mode: 0, value: "A deafened creature can't hear and automatically fails any ability check that requires hearing.", priority: 1},
+        ],
+        diseased: [],   //no changes
+        dodging: [
+            {key: "flags.midi-qol.grants.disadvantage.attack.all", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.advantage.ability.save.dex", mode: 0, value: "1", priority: 1}
+        ],
+        encumbered: [], //no changes
+        ethereal: [],   //no changes
+        exceedingCarryingCapacity: [],  //no changes
+        exhaustion: [], //no changes
+        flying: [],     //no changes
+        frightened: [],     //no changes
+        grappled: [
+            {key: "system.attributes.movement.all", mode: 0, value: "0", priority: 90},
+        ],
+        heavilyEncumbered: [],  //no changes
+        hiding: [],     //no changes
+        hovering: [],       //no changes
+        inaudible: [],      //no changes
+        incapacitated: [],  //no changes
+        invisible: [
+            {key: "flags.midi-qol.advantage.attack.all", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.grants.disadvantage.attack.all", mode: 0, value: "1", priority: 1},
+        ],      
+        marked: [],     //no changes
+        paralyzed: [
+            {key: "flags.midi-qol.fail.ability.save.str", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.fail.ability.save.dex", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.grants.advantage.attack.all", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.grants.critical.msak", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.grants.critical.mwak", mode: 0, value: "1", priority: 1},
+            {key: "flags.adv-reminder.grants.message.damage.all", mode: 0, value: "Any attack that hits a paralyzed creature is a critical hit if the attacker is within 5 feet of the creature.", priority: 1},
+        ],      
+        petrified: [
+            {key: "flags.midi-qol.grants.advantage.attack.all", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.fail.ability.save.str", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.fail.ability.save.dex", mode: 0, value: "1", priority: 1},
+            {key: "system.traits.dr.all", mode: 0, value: "1", priority: 1},
+            {key: "system.traits.ci.value", mode: 0, value: "poisoned", priority: 1},
+            {key: "system.traits.ci.value", mode: 0, value: "diseased", priority: 1},
+        ],
+        poisoned: [
+            {key: "flags.midi-qol.disadvantage.attack.all", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.disadvantage.ability.check.all", mode: 0, value: "1", priority: 1},
+        ],
+        prone: [
+            {key: "flags.midi-qol.disadvantage.attack.all", mode: 0, value: "1", priority: 1},
+            {key: "flags.adv-reminder.grants.message.attack.all", mode: 0, value: "An attack roll against a prone creature has advantage if the attacker is within 5 feet of the creature. Otherwise, the attack roll has disadvantage.", priority: 1},
+        ],
+        restrained: [
+            {key: "system.attributes.movement.all", mode: 0, value: "0", priority: 90},
+            {key: "flags.midi-qol.disadvantage.attack.all", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.grants.advantage.attack.all", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.disadvantage.ability.save.dex", mode: 0, value: "1", priority: 1},
+        ],
+        silenced: [],   //no changes
+        sleeping: [],   //no changes
+        stable: [],     //no changes
+        stunned: [
+            {key: "flags.midi-qol.fail.ability.save.str", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.fail.ability.save.dex", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.grants.advantage.attack.all", mode: 0, value: "1", priority: 1},
+        ],
+        surprised: [],  //no changes
+        transformed: [],    //no changes
+        unconscious: [
+            {key: "flags.midi-qol.fail.ability.save.str", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.fail.ability.save.dex", mode: 0, value: "1", priority: 1},
+            {key: "flags.midi-qol.grants.advantage.attack.all", mode: 0, value: "1", priority: 1},
+            {key: "flags.adv-reminder.grants.message.damage.all", mode: 0, value: "Any attack that hits an unconscious creature is a critical hit if the attacker is within 5 feet of the creature.", priority: 1},
+        ],
+    }
+
+    for(const [key, value] of Object.entries(changesList)) {
+        if(!value.length) continue;
+        const effect = CONFIG.statusEffects.find(i => i.id === key);
+        if(!effect) continue;
+
+        effect.changes = value;
+    }
+}
+
+

--- a/allActors/homebrewRules.mjs
+++ b/allActors/homebrewRules.mjs
@@ -1,0 +1,9 @@
+export default {
+    _onInit() {
+        //  all of the keys have to be lowercase only for some reason!
+        CONFIG.DND5E.rules.legres = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.y7XsmDawHmZdSTTR";
+        CONFIG.DND5E.rules.alchemy = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.Z0XP4RuNUbFSIMVN";       //also in alchemy.mjs
+        CONFIG.DND5E.rules.craftingcontraptions = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.0pmGvF3yS5xoUoEU";  //also in craftingContraptions.mjs
+        CONFIG.DND5E.rules.triggeredabilities = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.DCZAvOjR2CqqnEpT";
+    }
+}

--- a/allActors/sharedMagicItems/guardianScales.mjs
+++ b/allActors/sharedMagicItems/guardianScales.mjs
@@ -1,0 +1,152 @@
+export default {
+    _onSetup() {
+        Hooks.on("preUpdateItem", (item, change) => {
+            if(change.system?.equipped === true) {
+                if(!allScaleItems.includes(item.name)) return;
+
+                //check if any other scale items are currently equipped and if so, give a warning and return false to cancel the equip update
+                if(item.actor.itemTypes.find(i => i.system.equipped === true && allScaleItems.includes(i.name))) {
+                    ui.notifications.info("You can equip no more than one Guardian Scale at once.");
+                    return false;
+                }
+                return guardianScalesCreate(item)
+            } else if (change.system?.equipped === false) {
+                if(!allScaleItems.includes(item.name)) return;
+                return guardianScalesDelete(item)
+            }
+        });
+    }
+}
+
+const allScaleItems = [
+"Guardian Scale of Abjuration",
+"Guardian Scale of Conjuration",
+"Guardian Scale of Divination",
+"Guardian Scale of Enchantment",
+"Guardian Scale of Evocation",
+"Guardian Scale of Illusion",
+"Guardian Scale of Necromancy",
+"Guardian Scale of Transmutation",
+];
+
+async function guardianScalesDelete(item) {
+    //if it's a different item, it should just return
+    const spellNames = getSpellNames(item.name);
+    if(!spellNames) return;
+
+    //find spell items with matching uuid flags and get their ids
+    const foundItemIds = item.actor.itemTypes.spell
+        .filter(i => i.flags["talia-custom"]?.grantedByUuid === item.uuid)
+        .map(i => i.id);
+    
+    //delete items
+    await Item.deleteDocuments(foundItemIds, {parent: item.actor});
+
+}
+
+async function guardianScalesCreate(item) {
+    //if it's a different item, it should just return
+    const spellNames = getSpellNames(item.name);
+    if(!spellNames) return;
+
+    const pack = game.packs.get("talia-custom.customItems");
+    const spellDocs = await pack.getDocuments({name__in: Object.values(spellNames)});
+    const spellObj = spellDocs.map(i => i.toObject());
+
+
+    const rollData = item.actor.getRollData();
+    const saveDC = 12 + rollData.attributes.prof;
+    const spellAttack = 4 + rollData.attributes.prof;
+
+
+    //alter each spell object
+    for(const obj of spellObj) {
+        const isCantrip = obj.system.level === 0 ? true : false;
+        const changes = {
+            flags: {
+                "talia-custom": {
+                    grantedByUuid: item.uuid,
+                }
+            },
+            system: {
+                activation: {
+                    type: isCantrip ? "bonus" : obj.system.activation.type,     //set cantrips to bonus action
+                },
+                attack: {
+                    flat: true,
+                    bonus: spellAttack,
+                },
+                preparation: {
+                    mode: "innate"
+                },
+                properties: ["wild", "mgc"],
+                save: {
+                    sacaling: "flat",
+                    dc: saveDC,
+                },
+                consume: {
+                    amount: isCantrip ? null : 1,
+                    scale: false,
+                    target: isCantrip ? null : item.id,
+                    type: isCantrip ? "" : "charges",
+                },
+                materials: {
+                    consumed: false,
+                    cost: 0,
+                    supply: 0,
+                    value: ""
+                }
+            },
+        };
+        foundry.utils.mergeObject(obj, changes);
+    }
+
+    //creat the items on the actor
+    await Item.createDocuments(spellObj, {parent: item.actor});
+}
+
+
+
+function getSpellNames(itemName) {
+    const spellNames = {
+        cantrip: "",
+        spell: "",
+    }
+    switch (itemName) {
+        case "Guardian Scale of Abjuration":
+            spellNames.cantrip = "Resistance";
+            spellNames.spell = "Death Ward";
+            break;
+        
+        case "Guardian Scale of Conjuration":
+            spellNames.cantrip = "Mage Hand";
+            spellNames.spell = "Dimension Door";
+            break;
+        case "Guardian Scale of Divination":
+            spellNames.cantrip = "Revelation Through Battle";
+            spellNames.spell = "Arcane Eye";
+            break;
+        case "Guardian Scale of Enchantment":
+            spellNames.cantrip = "Vicious Mockery";
+            spellNames.spell = "Raulothim's Psychic Lance";
+            break;
+        case "Guardian Scale of Evocation":
+            spellNames.cantrip = "Sacred Flame";
+            spellNames.spell = "Fire Shield";
+            break;
+        case "Guardian Scale of Illusion":
+            spellNames.cantrip = "Minor Illusion";
+            spellNames.spell = "Phantasmal Horror";
+            break;
+        case "Guardian Scale of Necromancy":
+            spellNames.cantrip = "Toll the Dead";
+            spellNames.spell = "Blight";
+            break;
+        case "Guardian Scale of Transmutation":
+            spellNames.cantrip = "Thorn Whip";
+            spellNames.spell = "Guardian of Nature";
+            break;
+    }
+    if(spellNames.cantrip === "" || spellNames.spell === "") return;
+    else return spellNames;
+}

--- a/allActors/soulBoundItemProperty.mjs
+++ b/allActors/soulBoundItemProperty.mjs
@@ -1,0 +1,28 @@
+import { _foundryHelpers } from "../scripts/_foundryHelpers.mjs";
+
+export default {
+    _onInit() {
+        //add "Soul-Bound" item property to indicate items that can only be used by the character it's been given to
+        CONFIG.DND5E.itemProperties.soulBound = {
+            label: "Soul-Bound",
+            icon: "systems/dnd5e/icons/svg/items/equipment.svg"
+        };
+        //add item property "shareable" to all item types
+        CONFIG.DND5E.validProperties.consumable.add("soulBound");
+        CONFIG.DND5E.validProperties.container.add("soulBound");
+        CONFIG.DND5E.validProperties.equipment.add("soulBound");
+        CONFIG.DND5E.validProperties.loot.add("soulBound");
+        CONFIG.DND5E.validProperties.weapon.add("soulBound");
+        CONFIG.DND5E.validProperties.tool.add("soulBound");
+    },
+    _onSetup() {
+        Hooks.on("dnd5e.preDisplayCard", (item, chatData, options) => {
+            const validTypes = ["consumable", "container", "equipment", "loot", "weapon", "tool"];
+            if(!validTypes.includes(item.type) || !item.system?.properties?.has("soulBound")) return;
+        
+            //add new labels to chatCard
+            chatData.content = _foundryHelpers.insertListLabels(chatData.content, ["Soul-Bound"]);
+        });
+    }
+}
+

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 0.5.0 - 2024/08/06
+<details>
+<summary><h2>Fixed</h2></summary>
+
+- Renamed Plant Muscle Fibers to Plant Muscle Fibres so they can actually be harvested now.
+
 # 0.4.0 - 2024/07/30
 <details>
 <summary><h2>Added</h2></summary>

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,95 @@
 <details>
 <summary><h2>Added</h2></summary>
 
+-   <details>
+    <summary>Spells (spoiler warning)</summary>
+
+    - Arcane Eye
+    - Death Ward
+    - Fire Shield
+    - Guardian of Nature
+    - Raulothim's Psychic Lance
+    - Minor Illusion
+    -   <details>
+        <summary>Resistance (changed)</summary>
+
+        from
+        > You touch one willing creature. Once before the spell ends, the target can roll a d4 and add the number rolled to one saving throw of its choice. It can roll the die before or after making the saving throw. The spell then ends.
+
+        to
+        > You touch one willing creature. For the duration of the spell, the creature adds a d4 to all saving throws.
+        </details>
+    - Thorn Whip
+    - Vicious Mockery
+    - Revelation Through Battle
+    - Phantasmal Horror
+    </details>
+-   <details>
+    <summary>Magic Items (spoiler warning)</summary>
+
+    - Tankard of Plenty
+    - Guardian Scale of Abjuration
+    - Guardian Scale of Conjuration
+    - Guardian Scale of Divination
+    - Guardian Scale of Enchantment
+    - Guardian Scale of Evocation
+    - Guardian Scale of Illusion
+    - Guardian Scale of Necromancy
+    - Guardian Scale of Transmutation
+    </details>
+
+-   <details>
+    <summary>Item Property: Soul-Bound</summary>
+
+    This property can be found on item types that are normally tradeable (Equipment, Weapons, Consumables, Containers, Loot, and Tools).  
+    If set on an item, please don't trade it to others or put it into a storage chest that others have access to.
+
+    -   <details>
+        <summary>Aviana Soul-Bound items</summary>
+
+        - Lethal Limbs
+        - Strionic Resonator
+        - Spelleater's Charm
+        - Royal Commander's Cloak
+        - Grateful Fey's Charm
+        - Rod of Unwilling Retribution
+        - Cursed Thunderfeet Footwraps
+        </details>
+    
+    -   <details>
+        <summary>Fearghas Soul-Bound items</summary>
+
+        - High Priest's Obsidian Battleaxe
+        - Ring of Unbridled Power
+        - Rod of Hellish Flames
+        - Dead Knight's Chain Shirt
+        - Spellbook: Strength through suffering (of others)
+        - Spellbook: Unholy Grimoire of Blood
+        </details>
+
+    -   <details>
+        <summary>Plex Soul-Bound items</summary>
+
+        - Sneaky Spellshite's Amulet
+        - Mantle of the Arcane Trickster
+        - Swiftstrider's Boots
+        - Shaman's Lucky Charms
+        - Sun Statue
+
+        </details>
+
+    -   <details>
+        <summary>Shalkoc Soul-Bound items</summary>
+
+        - Unarmed Strike (Draconic Strike)
+        - Drunken Brawler's Dancing Shoes
+        - Handwraps of Swift Strikes
+        - Necklace of Mighty Breath
+        - +3 Dragonhide Belt
+        - Wyrmreaver Gauntlets
+        </details>
+
+    </details>
 - Common Action: Dodge
 -   <details>
     <summary>The following status conditions now have actual effects</summary>
@@ -29,6 +118,7 @@
 - Breath of the Dragon now has the correct number of free uses per day instead of half. Also fixed it's description.
 </details>
 
+<details>
 <summary><h2>Dev Details</h2></summary>  
 
 - API function `TaliaCustom.breathOfTheDragonDialog(item)`
@@ -38,6 +128,8 @@
     Rolls inspiration for each active player and whispers the result to a different player.
     The generated chat message is also pinned.
 
+- _foundryHelpers function `insertListLabels(htmlString, newLabels)`
+    Used to add item properties to chat cards. Added to Wild and Soul-Bound properties. 
 </details>
 
 # 0.4.0 - 2024/07/30

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,23 @@
 # 0.5.0 - 2024/08/06
 <details>
+<summary><h2>Added</h2></summary>
+
+- Macro for assigning player inspirations
+</details>
+
+<details>
 <summary><h2>Fixed</h2></summary>
 
 - Renamed Plant Muscle Fibers to Plant Muscle Fibres so they can actually be harvested now.
+</details>
+
+<summary><h2>Dev Details</h2></summary>  
+
+- API function `TaliaCustom.gmScripts.playerInspirations()`
+    Rolls inspiration for each active player and whispers the result to a different player.
+    The generated chat message is also pinned.
+
+</details>
 
 # 0.4.0 - 2024/07/30
 <details>

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,23 @@
 <details>
 <summary><h2>Added</h2></summary>
 
+- Common Action: Dodge
+-   <details>
+    <summary>The following status conditions now have actual effects</summary>
+
+    - blinded
+    - deafened
+    - dodging
+    - grappled (only setting movement to 0 for now)
+    - invisible
+    - paralyzed
+    - petrified
+    - poisoned
+    - prone
+    - restrained
+    - stunned
+    - unconscious
+    </details>
 - Macro for assigning player inspirations
 </details>
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,42 +2,8 @@
 <details>
 <summary><h2>Added</h2></summary>
 
--   <details>
-    <summary>Spells (spoiler warning)</summary>
-
-    - Arcane Eye
-    - Death Ward
-    - Fire Shield
-    - Guardian of Nature
-    - Raulothim's Psychic Lance
-    - Minor Illusion
-    -   <details>
-        <summary>Resistance (changed)</summary>
-
-        from
-        > You touch one willing creature. Once before the spell ends, the target can roll a d4 and add the number rolled to one saving throw of its choice. It can roll the die before or after making the saving throw. The spell then ends.
-
-        to
-        > You touch one willing creature. For the duration of the spell, the creature adds a d4 to all saving throws.
-        </details>
-    - Thorn Whip
-    - Vicious Mockery
-    - Revelation Through Battle
-    - Phantasmal Horror
-    </details>
--   <details>
-    <summary>Magic Items (spoiler warning)</summary>
-
-    - Tankard of Plenty
-    - Guardian Scale of Abjuration
-    - Guardian Scale of Conjuration
-    - Guardian Scale of Divination
-    - Guardian Scale of Enchantment
-    - Guardian Scale of Evocation
-    - Guardian Scale of Illusion
-    - Guardian Scale of Necromancy
-    - Guardian Scale of Transmutation
-    </details>
+- Rules: Legendary Resistances
+- Rules: Triggered Abilities
 
 -   <details>
     <summary>Item Property: Soul-Bound</summary>
@@ -109,17 +75,77 @@
     - unconscious
     </details>
 - Macro for assigning player inspirations
+-   <details>
+    <summary>Spells (spoiler warning)</summary>
+
+    - Arcane Eye
+    - Death Ward
+    - Fire Shield
+    - Guardian of Nature
+    - Raulothim's Psychic Lance
+    - Minor Illusion
+    -   <details>
+        <summary>Resistance (changed)</summary>
+
+        from
+        > You touch one willing creature. Once before the spell ends, the target can roll a d4 and add the number rolled to one saving throw of its choice. It can roll the die before or after making the saving throw. The spell then ends.
+
+        to
+        > You touch one willing creature. For the duration of the spell, the creature adds a d4 to all saving throws.
+        </details>
+    - Thorn Whip
+    - Vicious Mockery
+    - Revelation Through Battle
+    - Phantasmal Horror
+    </details>
+-   <details>
+    <summary>Magic Items (spoiler warning)</summary>
+
+    - Tankard of Plenty
+    - Guardian Scale of Abjuration
+    - Guardian Scale of Conjuration
+    - Guardian Scale of Divination
+    - Guardian Scale of Enchantment
+    - Guardian Scale of Evocation
+    - Guardian Scale of Illusion
+    - Guardian Scale of Necromancy
+    - Guardian Scale of Transmutation
+    - Broken Sentinel Statue (alongside Ironfeather Sentinel actor)
+    </details>
+
+-   <details>
+    <summary>Mythic Features (major spoiler warning!)</summary>
+
+    - Mythic Power (1 for each)
+    - Legendary Vigor
+    - Titanous Strength
+    - Fishy Magic
+    - Master of Chance
+    - Rejuvination
+    - Legendary Resistance
+    - The Price of Knowledge
+    - Spectral Hand
+    </details>
+
 </details>
 
 <details>
 <summary><h2>Fixed</h2></summary>
 
+- Attunements not working (very bandaid fix, will likely break again, system devs have no idea what's causing it and don't want to provide support since the bug isn't happening in never versions).
 - Renamed Plant Muscle Fibers to Plant Muscle Fibres so they can actually be harvested now.
 - Breath of the Dragon now has the correct number of free uses per day instead of half. Also fixed it's description.
 </details>
 
 <details>
-<summary><h2>Dev Details</h2></summary>  
+<summary><h2>Dev Details (also major spoiler warning)</h2></summary>  
+
+- added flag `flags.talia-custom.mythicRank` = 0 to every player character.
+- added macro "Set Mythic Rank" which sets the mythic rank for selected actor. 
+    For player characters it also changes their alignment to instead dislpay their mythic path and rank.
+
+- added macro "Recharge Mythic Power" which Simple Calendar will execute every sunday ingame.
+    It recharges any expended uses of Mythic Power for all characters which have `flags.talia-custom.mythicRank` set to a truthy value.
 
 - API function `TaliaCustom.breathOfTheDragonDialog(item)`
     ItemMacro for Breath of the Dragon

--- a/changelog.md
+++ b/changelog.md
@@ -9,9 +9,13 @@
 <summary><h2>Fixed</h2></summary>
 
 - Renamed Plant Muscle Fibers to Plant Muscle Fibres so they can actually be harvested now.
+- Breath of the Dragon now has the correct number of free uses per day instead of half. Also fixed it's description.
 </details>
 
 <summary><h2>Dev Details</h2></summary>  
+
+- API function `TaliaCustom.breathOfTheDragonDialog(item)`
+    ItemMacro for Breath of the Dragon
 
 - API function `TaliaCustom.gmScripts.playerInspirations()`
     Rolls inspiration for each active player and whispers the result to a different player.

--- a/gmScriptsAndMacros/playerInspirations.mjs
+++ b/gmScriptsAndMacros/playerInspirations.mjs
@@ -1,0 +1,64 @@
+import { TaliaCustomAPI } from "../scripts/api.mjs";
+
+export default {
+    _onSetup() {
+        TaliaCustomAPI.add({
+            gmScripts: {
+                playerInspirations,
+            }
+        })
+    }
+}
+
+async function playerInspirations() {
+    const packFolder = game.packs.get("talia-custom.rollable-tables").folders.find(f => f.name === "Inspirations");
+    const activePlayers = game.users.players.filter(p => p.active === true) //TODO only set to false for testing!
+    
+    const names = activePlayers.map(obj => obj.name);
+    // generate an object with player names as keys and objects as values
+    // each value has another player's name as a value of the key 'targetName'
+    const pairs = (() => {
+        const n = names.length;
+        // Fisher-Yates shuffle
+        for (let i = n - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [names[i], names[j]] = [names[j], names[i]];
+        }
+        // Create the pairings with a simple shift
+        const pairs = {};
+        for (let i = 0; i < n; i++) {
+            pairs[names[i]] = {targetName: names[(i + 1) % n]};
+        }
+        return pairs;
+    })();
+    
+    for(const [key, value] of Object.entries(pairs)) {
+        const tableUuid = packFolder.contents.find(t => t.name.includes(value.targetName)).uuid;
+        const table = await fromUuid(tableUuid);
+        
+        //roll each result (rr so they can never be the same) and add the roll and the text results to pairs
+        const tableSize = table.results.size;
+        value.tableRoll = await new Roll(`1d${tableSize}rr(1d${tableSize})`).evaluate();
+        value.tableTextResults = value.tableRoll.dice.map(d => {
+            const indexVal = d.total - 1;
+            return table.results.contents[indexVal].text;    
+        });
+        
+        //generate the text for the message
+        const content = `
+            <h3>Inspirations for <b>${value.targetName}</b></h3>
+            <p>${value.tableTextResults[0]}</p>
+            <p>${value.tableTextResults[1]}</p>
+            `;
+            
+        const speaker = ChatMessage.getSpeaker({alias: "Aerelia"});
+        await game.dice3d.showForRoll(value.tableRoll, game.user, true, null, false, null, speaker);
+        const msg = await ChatMessage.create({
+            speaker: speaker,
+            content,
+            whisper: [activePlayers.find(p => p.name === key)._id],
+        });
+        //pin for all
+        game.modules.get("pinned-chat-message").api.pinnedMessage(msg);
+    }
+}

--- a/gmScriptsAndMacros/playerInspirations.mjs
+++ b/gmScriptsAndMacros/playerInspirations.mjs
@@ -12,7 +12,7 @@ export default {
 
 async function playerInspirations() {
     const packFolder = game.packs.get("talia-custom.rollable-tables").folders.find(f => f.name === "Inspirations");
-    const activePlayers = game.users.players.filter(p => p.active === true) //TODO only set to false for testing!
+    const activePlayers = game.users.players.filter(p => p.active === true)
     
     const names = activePlayers.map(obj => obj.name);
     // generate an object with player names as keys and objects as values

--- a/scripts/_foundryHelpers.mjs
+++ b/scripts/_foundryHelpers.mjs
@@ -8,6 +8,7 @@ export const _foundryHelpers = {
     consumeItem,
     displayItemWithoutEffects,
     getUserIdsArray,
+    insertListLabels,
     SECONDS: {
         IN_ONE_MINUTE: 60,
         IN_TEN_MINUTES: 600,
@@ -235,4 +236,58 @@ async function rollTableGrantItems(actor, tableUuid, {drawsNum = 1, fractionOfTa
     }, {}));
 
     return actor.createEmbeddedDocuments("Item", combinedItemsArray);
+}
+
+/**
+ * Inserts new list items into an HTML string containing a ul element with class "card-footer pills unlist".
+ * Each new item is added only if its label doesn't already exist in the list.
+ * 
+ * @param {string} htmlString - The original HTML string containing the ul element.
+ * @param {string[]} newLabels - An array of strings to be added as new list item labels.
+ * @returns {string} The modified HTML string with new list items added.
+ */
+function insertListLabels(htmlString, newLabels) {
+    // Create a temporary DOM element to parse the HTML string
+    const tempElement = document.createElement('div');
+    tempElement.innerHTML = htmlString;
+
+    // Find the target ul element
+    const ulElement = tempElement.querySelector('ul.card-footer.pills.unlist');
+
+    if (ulElement) {
+        // Get existing labels
+        const existingLabels = Array.from(ulElement.querySelectorAll('li span.label'))
+        .map(span => span.textContent.trim().toLowerCase());
+
+        // Process each new label
+        newLabels.forEach(label => {
+            const normalizedLabel = label.trim().toLowerCase();
+            
+            // Check if the label already exists
+            if (!existingLabels.includes(normalizedLabel)) {
+                // Create a new li element
+                const newLi = document.createElement('li');
+                newLi.className = 'pill pill-sm';
+                
+                // Create a new span element
+                const newSpan = document.createElement('span');
+                newSpan.className = 'label';
+                newSpan.textContent = label.trim();
+                
+                // Append the span to the li, and the li to the ul
+                newLi.appendChild(newSpan);
+                ulElement.appendChild(newLi);
+                
+                // Add to existing labels to prevent duplicates
+                existingLabels.push(normalizedLabel);
+            }
+        });
+
+        // Return the modified HTML as a string
+        return tempElement.innerHTML;
+    } else {
+        // If the target ul is not found, return the original string
+        console.warn('Target ul not found');
+        return htmlString;
+    }
 }

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -2,7 +2,7 @@ import { MODULE } from "./constants.mjs"
 import { setupSocket } from "./socket.mjs";
 import { TaliaCustomAPI } from "./api.mjs";
 
-
+import _spells from "../spells/_spells.mjs";
 import beastSpirits from "../aviana/items/beastSpirits.mjs";
 import wildMagic from "../wildMagic/wildMagic.mjs";
 import cooking from "../shalkoc/cooking.mjs";
@@ -19,13 +19,14 @@ import { helpersToApi } from "./_foundryHelpers.mjs";
 import templateOpenCharSheet from "../systemChanges/templateOpenCharSheet.mjs";
 import alchemy from "../alchemy/alchemy.mjs";
 import tokenAdjacencyCheck from "../inGame-macrosAndScripts/tokenAdjacencyCheck.mjs";
-import skillEmpowerment from "../spells/skillEmpowerment.mjs";
 import martialStyleStances from "../shalkoc/Feats/martialStyleStances.mjs";
 import mythicRanks from "../allActors/mythicRanks.mjs";
 import mantleOfTheArcaneTrickster from "../plex/contraptionsCrafting/items/mantleOfTheArcaneTrickster.mjs";
 import playerInspirations from "../gmScriptsAndMacros/playerInspirations.mjs";
 import breathOfTheDragon from "../shalkoc/Feats/breathOfTheDragon.mjs";
 import changesToConditions from "../allActors/changesToConditions.mjs";
+import soulBoundItemProperty from "../allActors/soulBoundItemProperty.mjs";
+import guardianScales from "../allActors/sharedMagicItems/guardianScales.mjs";
 
 Hooks.once("socketlib.ready", () => {
     setupSocket();
@@ -48,10 +49,12 @@ Hooks.once("init", () => {
     martialStyleStances._onInit();
     mythicRanks._onInit();
     changesToConditions._onInit();
+    soulBoundItemProperty._onInit();
 });
 
 Hooks.once("setup", () => {
     TaliaCustomAPI._setup();
+    _spells._onSetup();     //collection for all spell scripts
     cooking._onSetup();
     wildMagic._onSetup();
     beastSpirits._onSetup();
@@ -64,11 +67,12 @@ Hooks.once("setup", () => {
     helpersToApi._onSetup();
     alchemy._onSetup();
     tokenAdjacencyCheck._onSetup();
-    skillEmpowerment._onSetup();
     martialStyleStances._onSetup();
     mantleOfTheArcaneTrickster._onSetup();
     playerInspirations._onSetup();
     breathOfTheDragon._onSetup();
+    soulBoundItemProperty._onSetup();
+    guardianScales._onSetup();
 
     console.log(`${MODULE.ID} set up.`);
 });

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -25,6 +25,7 @@ import mythicRanks from "../allActors/mythicRanks.mjs";
 import mantleOfTheArcaneTrickster from "../plex/contraptionsCrafting/items/mantleOfTheArcaneTrickster.mjs";
 import playerInspirations from "../gmScriptsAndMacros/playerInspirations.mjs";
 import breathOfTheDragon from "../shalkoc/Feats/breathOfTheDragon.mjs";
+import changesToConditions from "../allActors/changesToConditions.mjs";
 
 Hooks.once("socketlib.ready", () => {
     setupSocket();
@@ -46,6 +47,7 @@ Hooks.once("init", () => {
     alchemy._onInit();
     martialStyleStances._onInit();
     mythicRanks._onInit();
+    changesToConditions._onInit();
 });
 
 Hooks.once("setup", () => {

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -23,6 +23,7 @@ import skillEmpowerment from "../spells/skillEmpowerment.mjs";
 import martialStyleStances from "../shalkoc/Feats/martialStyleStances.mjs";
 import mythicRanks from "../allActors/mythicRanks.mjs";
 import mantleOfTheArcaneTrickster from "../plex/contraptionsCrafting/items/mantleOfTheArcaneTrickster.mjs";
+import playerInspirations from "../gmScriptsAndMacros/playerInspirations.mjs";
 
 Hooks.once("socketlib.ready", () => {
     setupSocket();
@@ -63,6 +64,7 @@ Hooks.once("setup", () => {
     skillEmpowerment._onSetup();
     martialStyleStances._onSetup();
     mantleOfTheArcaneTrickster._onSetup();
+    playerInspirations._onSetup();
 
     console.log(`${MODULE.ID} set up.`);
 });

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -27,6 +27,7 @@ import breathOfTheDragon from "../shalkoc/Feats/breathOfTheDragon.mjs";
 import changesToConditions from "../allActors/changesToConditions.mjs";
 import soulBoundItemProperty from "../allActors/soulBoundItemProperty.mjs";
 import guardianScales from "../allActors/sharedMagicItems/guardianScales.mjs";
+import homebrewRules from "../allActors/homebrewRules.mjs";
 
 Hooks.once("socketlib.ready", () => {
     setupSocket();
@@ -50,6 +51,7 @@ Hooks.once("init", () => {
     mythicRanks._onInit();
     changesToConditions._onInit();
     soulBoundItemProperty._onInit();
+    homebrewRules._onInit();
 });
 
 Hooks.once("setup", () => {

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -24,6 +24,7 @@ import martialStyleStances from "../shalkoc/Feats/martialStyleStances.mjs";
 import mythicRanks from "../allActors/mythicRanks.mjs";
 import mantleOfTheArcaneTrickster from "../plex/contraptionsCrafting/items/mantleOfTheArcaneTrickster.mjs";
 import playerInspirations from "../gmScriptsAndMacros/playerInspirations.mjs";
+import breathOfTheDragon from "../shalkoc/Feats/breathOfTheDragon.mjs";
 
 Hooks.once("socketlib.ready", () => {
     setupSocket();
@@ -65,6 +66,7 @@ Hooks.once("setup", () => {
     martialStyleStances._onSetup();
     mantleOfTheArcaneTrickster._onSetup();
     playerInspirations._onSetup();
+    breathOfTheDragon._onSetup();
 
     console.log(`${MODULE.ID} set up.`);
 });

--- a/shalkoc/Feats/breathOfTheDragon.mjs
+++ b/shalkoc/Feats/breathOfTheDragon.mjs
@@ -1,0 +1,87 @@
+import { TaliaCustomAPI } from "../../scripts/api.mjs";
+
+
+export default {
+    _onSetup() {
+        TaliaCustomAPI.add({
+            breathOfTheDragonDialog
+        })
+    }
+}
+
+async function breathOfTheDragonDialog(item) {
+    const kiItem = item.actor.items.get(item.system.consume.target);
+    
+    const damageTypes = ['acid', 'cold', 'fire', 'lightning', 'poison'];
+
+    const content = `
+        <form>
+            <div class="form-group">
+                <label>Shape</label>
+                <div class="form-fields">
+                    <select name="shape">
+                        <option value="line">Line</option>
+                        <option value="cone">Cone</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group">
+                <label>Consume</label>
+                <div class="form-fields">
+                    <select name="consume">
+                        <option value="uses">Uses (${item.system.uses.value}/${item.system.uses.max}</option>
+                        <option value="ki">${item.system.consume.amount} Ki (${kiItem.system.uses.value}/${kiItem.system.uses.max})</option>
+                    </select>
+                </div>
+            </div>
+        </form>`;
+
+    const buttons = {};
+    for(const type of damageTypes) {
+        buttons[type] = {
+            label: CONFIG.DND5E.damageTypes[type].label,
+            callback: ([html]) => {
+                return { 
+                    ...new FormDataExtended(html.querySelector("form")).object,
+                    damageType: type
+                }
+            }
+        }
+    }
+
+    const choices = await Dialog.wait({
+        title: item.name,
+        content,
+        buttons,
+        close: () => null
+    });
+    if(!choices) return false;
+
+    const itemSystem = {
+        target: {
+            type: choices.shape,
+            value: choices.shape === "line" ? 30 : 20,
+            width: choices.shape === "line" ? 5 : null,
+        },
+        damage: {
+            parts: [[item.system.damage.parts[0][0], choices.damageType]],
+        }
+    }
+
+    await item.actor.updateEmbeddedDocuments("Item", [{_id: item._id, "system": itemSystem}]);
+
+    const config = {
+        consumeUsage: choices.consume === "uses" ? true : null,
+        consumeResource: choices.consume === "uses" ? null : true
+    }
+    const options = {
+        skipItemMacro: true, 
+        configureDialog: false,
+        flags: {
+            "dnd5e.use.consumedUsage": true,
+            "dnd5e.use.consumedResource": true,
+        }
+    }
+
+    return await item.use(config, options);
+}

--- a/spells/_spells.mjs
+++ b/spells/_spells.mjs
@@ -1,0 +1,14 @@
+import { TaliaCustomAPI } from "../scripts/api.mjs"
+import { revelationThroughBattle } from "./revelationThroughBattle.mjs"
+import { skillEmpowerment } from "./skillEmpowerment.mjs"
+
+export default {
+    _onSetup() {
+        TaliaCustomAPI.add({
+            Spells: {
+                skillEmpowerment,
+                revelationThroughBattle
+            }
+        })
+    }
+}

--- a/spells/revelationThroughBattle.mjs
+++ b/spells/revelationThroughBattle.mjs
@@ -1,0 +1,47 @@
+
+
+export async function revelationThroughBattle(item, deleteAfterMS) {
+    const target = game.user.targets?.first();
+    if(!target) {
+        ui.notifications.info("If you cannot target a token, just ask for the info.");
+        return false;
+    }
+
+    const rollData = target.actor.getRollData();
+    const savesString = Object.entries(rollData.abilities).reduce((acc, [key, value]) => {
+        return acc += `<p>${CONFIG.DND5E.abilities[key].label}: ${value.save}</p>`;
+    }, "");
+    const drString = Array.from(rollData.traits.dr.value)
+        .map(i => CONFIG.DND5E.damageTypes[i].label)
+        .join(", ");
+    const dvString = Array.from(rollData.traits.dv.value)
+        .map(i => CONFIG.DND5E.damageTypes[i].label)
+        .join(", ");
+    const diString = Array.from(rollData.traits.di.value)
+        .map(i => CONFIG.DND5E.damageTypes[i].label)
+        .join(", ");
+    const ciString = Array.from(rollData.traits.ci.value)
+        .map(i => CONFIG.DND5E.conditionTypes[i].label)
+        .join(", ");
+        
+    const content = `
+        <h3>AC & Saving throw bonuses</h3>
+        <p>AC: ${rollData.attributes.ac.value}</p>
+        ${savesString}
+        ${diString.length ? `<h3>Damage Immunities</h3><p>${diString}</p>` : ""}
+        ${drString.length ? `<h3>Damage Resistances</h3><p>${drString}</p>` : ""}
+        ${dvString.length ? `<h3>Damage Vulnerabilities</h3><p>${dvString}</p>` : ""}
+        ${ciString.length ? `<h3>Condition Immunities</h3><p>${ciString}</p>` : ""}
+    `;
+
+    //display spell card first
+    await item.displayCard();
+
+    const msg = await ChatMessage.create({
+        content,
+        whisper: [game.users.activeGM.id],
+        speaker: ChatMessage.implementation.getSpeaker({actor: item.actor}),
+    });
+
+    setTimeout(async() => await msg.delete(), deleteAfterMS);
+}

--- a/spells/skillEmpowerment.mjs
+++ b/spells/skillEmpowerment.mjs
@@ -1,17 +1,5 @@
-import { TaliaCustomAPI } from "../scripts/api.mjs"
-
-export default {
-    _onSetup() {
-        TaliaCustomAPI.add({
-            Spells: {
-                skillEmpowerment
-            }
-        })
-    }
-}
-
 // called from item macro
-async function skillEmpowerment(item) {
+export async function skillEmpowerment(item) {
     const targetActor = game.user.targets.first()?.actor;
     const effect = item.effects?.contents[0];
     if(!targetActor || !effect) return false;

--- a/wildMagic/wildMagic.mjs
+++ b/wildMagic/wildMagic.mjs
@@ -6,6 +6,7 @@
 
 import { surgesTable } from "./surgesTable.mjs";
 import { TaliaCustomAPI } from "../scripts/api.mjs";
+import { _foundryHelpers } from "../scripts/_foundryHelpers.mjs";
 
 export default {
     _onInit() {
@@ -32,6 +33,13 @@ export default {
             const surge = await Surge.causeSurge();
             const actor = item.actor || canvas.tokens.controlled[0]?.actor;
             await Surge.createChatMessage(surge, actor);
+        });
+
+        Hooks.on("dnd5e.preDisplayCard", (item, chatData, options) => {
+            if(!item.system?.properties.has("wild")) return;
+
+            //add new labels to chatCard
+            chatData.content = _foundryHelpers.insertListLabels(chatData.content, ["Wild"]);
         });
     }
 }


### PR DESCRIPTION
closes #103 
closes #102 
closes #105 
closes #101 

# 0.5.0 - 2024/08/06
<details>
<summary><h2>Added</h2></summary>

- Rules: Legendary Resistances
- Rules: Triggered Abilities

-   <details>
    <summary>Item Property: Soul-Bound</summary>

    This property can be found on item types that are normally tradeable (Equipment, Weapons, Consumables, Containers, Loot, and Tools).  
    If set on an item, please don't trade it to others or put it into a storage chest that others have access to.

    -   <details>
        <summary>Aviana Soul-Bound items</summary>

        - Lethal Limbs
        - Strionic Resonator
        - Spelleater's Charm
        - Royal Commander's Cloak
        - Grateful Fey's Charm
        - Rod of Unwilling Retribution
        - Cursed Thunderfeet Footwraps
        </details>
    
    -   <details>
        <summary>Fearghas Soul-Bound items</summary>

        - High Priest's Obsidian Battleaxe
        - Ring of Unbridled Power
        - Rod of Hellish Flames
        - Dead Knight's Chain Shirt
        - Spellbook: Strength through suffering (of others)
        - Spellbook: Unholy Grimoire of Blood
        </details>

    -   <details>
        <summary>Plex Soul-Bound items</summary>

        - Sneaky Spellshite's Amulet
        - Mantle of the Arcane Trickster
        - Swiftstrider's Boots
        - Shaman's Lucky Charms
        - Sun Statue

        </details>

    -   <details>
        <summary>Shalkoc Soul-Bound items</summary>

        - Unarmed Strike (Draconic Strike)
        - Drunken Brawler's Dancing Shoes
        - Handwraps of Swift Strikes
        - Necklace of Mighty Breath
        - +3 Dragonhide Belt
        - Wyrmreaver Gauntlets
        </details>

    </details>
- Common Action: Dodge
-   <details>
    <summary>The following status conditions now have actual effects</summary>

    - blinded
    - deafened
    - dodging
    - grappled (only setting movement to 0 for now)
    - invisible
    - paralyzed
    - petrified
    - poisoned
    - prone
    - restrained
    - stunned
    - unconscious
    </details>
- Macro for assigning player inspirations
-   <details>
    <summary>Spells (spoiler warning)</summary>

    - Arcane Eye
    - Death Ward
    - Fire Shield
    - Guardian of Nature
    - Raulothim's Psychic Lance
    - Minor Illusion
    -   <details>
        <summary>Resistance (changed)</summary>

        from
        > You touch one willing creature. Once before the spell ends, the target can roll a d4 and add the number rolled to one saving throw of its choice. It can roll the die before or after making the saving throw. The spell then ends.

        to
        > You touch one willing creature. For the duration of the spell, the creature adds a d4 to all saving throws.
        </details>
    - Thorn Whip
    - Vicious Mockery
    - Revelation Through Battle
    - Phantasmal Horror
    </details>
-   <details>
    <summary>Magic Items (spoiler warning)</summary>

    - Tankard of Plenty
    - Guardian Scale of Abjuration
    - Guardian Scale of Conjuration
    - Guardian Scale of Divination
    - Guardian Scale of Enchantment
    - Guardian Scale of Evocation
    - Guardian Scale of Illusion
    - Guardian Scale of Necromancy
    - Guardian Scale of Transmutation
    - Broken Sentinel Statue (alongside Ironfeather Sentinel actor)
    </details>

-   <details>
    <summary>Mythic Features (major spoiler warning!)</summary>

    - Mythic Power (1 for each)
    - Legendary Vigor
    - Titanous Strength
    - Fishy Magic
    - Master of Chance
    - Rejuvination
    - Legendary Resistance
    - The Price of Knowledge
    - Spectral Hand
    </details>

</details>

<details>
<summary><h2>Fixed</h2></summary>

- Attunements not working (very bandaid fix, will likely break again, system devs have no idea what's causing it and don't want to provide support since the bug isn't happening in never versions).
- Renamed Plant Muscle Fibers to Plant Muscle Fibres so they can actually be harvested now.
- Breath of the Dragon now has the correct number of free uses per day instead of half. Also fixed it's description.
</details>

<details>
<summary><h2>Dev Details (also major spoiler warning)</h2></summary>  

- added flag `flags.talia-custom.mythicRank` = 0 to every player character.
- added macro "Set Mythic Rank" which sets the mythic rank for selected actor. 
    For player characters it also changes their alignment to instead dislpay their mythic path and rank.

- added macro "Recharge Mythic Power" which Simple Calendar will execute every sunday ingame.
    It recharges any expended uses of Mythic Power for all characters which have `flags.talia-custom.mythicRank` set to a truthy value.

- API function `TaliaCustom.breathOfTheDragonDialog(item)`
    ItemMacro for Breath of the Dragon

- API function `TaliaCustom.gmScripts.playerInspirations()`
    Rolls inspiration for each active player and whispers the result to a different player.
    The generated chat message is also pinned.

- _foundryHelpers function `insertListLabels(htmlString, newLabels)`
    Used to add item properties to chat cards. Added to Wild and Soul-Bound properties. 
</details>