### PR TITLE
1.6.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,103 @@
+# 1.6.0 - 2024/10/22
+
+<details>
+<summary><h2>Added</h2></summary>
+
+- 'Fixed' Necklace of Mighty Breath by adding an upgraded version.
+- Spirit of the Eagle features
+    - Spirit of the Eagle
+    - Keen Sight
+    - Billowing Wings
+    - Diving Strike
+    - Double Down
+- Condition "Distracted"
+    > A distracted creature cannot take reactions.
+</details>
+
+<details>
+<summary><h2>Changed</h2></summary>
+
+- Activating (changing to) a new Beast Spirit can now cause a wild magic surge.
+- Spirit of the Bear: Reduced the duration of the Taunted effect from Savage Taunt and Compelled Duel from three turns to two turns.
+-   <details>
+    <summary>Spirit of the Elk</summary>
+
+    -   Adept Forager (unchanged)
+    -   <details>
+        <summary>Stampede -> Battering Ram</summary>
+
+        from
+        > As a bonus action, you charge forward in a straight line up to a distance equal to your maximum jump distance.
+        > You pass through creatures in your path, pushing them backward in the direction of your charge. The distance each creature is pushed is equal to the distance you can shove a creature of that size.
+        > Colliding with a creature does not slow or stop your charge.
+
+        to
+        > When you take the Attack action on your turn, you can replace one of your attacks with a special charge attack.
+        >
+        > You move up to 50 feet in a straight line that is 5 feet wide, stopping when you hit the first creature in your path. The creature must make a Strength saving throw (DC = 8 + your Strength modifier + your Constitution modifier + your proficiency bonus). On a failed save, the creature takes 1d12 + your Strength modifier bludgeoning damage and is knocked back a distance equal to how far you charged before hitting it (to a maximum of 50 feet).
+        >
+        > If the creature is knocked back into another creature or a solid object, additional effects occur based on the distance it was knocked back:
+        >
+        > - Less than 30 feet: The creature is distracted until the start of its next turn.
+        > - 30 to 40 feet: The creature is restrained until the end of its next turn.
+        > - More than 40 feet: The creature is paralyzed until the end of its next turn.
+        >
+        > If the creature collides with another creature, both creatures suffer the same effect.
+        </details>
+    
+    -   <details>
+        <summary>Survival Instincts</summary>
+
+        from
+        > When you use Stampede, you gain an amount of temporary hit points equal to your barbarian level.
+        > Additionally, the distance you're able to shove a creature is increased by 10ft.
+
+        to
+        > Your walking speed is increased by 20ft, you have a 1d6 bonus to your initiative rolls and, as long as you aren't incapacitated, you cannot be surprised.
+        > Using Battering Ram grants you an amount of temporary hit points equal to your barbarian level.
+        </details>
+    
+    -   <details>
+        <summary>Unstoppable</summary>
+
+        from
+        > As long as you're not incapacitated, your movement speed cannot be reduced.
+        > 
+        > Additionally, when using Stampede, you can charge through and break objects, such as walls, up to 5ft thick.
+        > Stampede can also charge through magical barriers by succeeding on a Strength saving throw against the caster's spell save DC. If the barrier requires concentration to sustain, breaking through it immediately ends the caster's concentration.
+
+        to
+        > As long as you're not incapacitated, your movement speed cannot be reduced and you are immune to being frightened, restrained, grappled, or knocked prone..
+        >
+        > Additionally, you can use Battering Ram to charge through and break solid objects, such as walls, up to 5ft thick.
+        > You can also charge through and create holes in magical barriers this way if you succeed on a Strength saving throw against the caster's spell save DC. If the barrier requires concentration to maintain, breaking through it immediately ends the caster's concentration on the barrier.
+        </details>
+    </details>
+</details>
+
+<details>
+<summary><h2>Fixed</h2></summary>
+
+- Feral Instinct now correctly grants advantage on automatic initiative rolls
+- Applying the incapacitated status no longer throws an error (fixed in DAE 11.3.65)
+- Continual Flame Gem no longer duplicates auras.
+- Beast Spirit Blessing activations appearing twice in the chat log.
+-   <details>
+    <summary>Barbaric Critical</summary>
+
+    Fixed the deleted effect and clarified the wording of the ability so it better reflects the implementation.
+
+    from
+    > Attack rolls against you or creatures within 5ft of you have their critical hit threshold reduced by 1. When you reach level 13 and 17, this increases to a reduction in critical hit threshold of 2 and 3 respectively.
+    >
+    > Additionally whenever a hostile creature scores a critical hit against you, you recover 1 spent Rage. When you reach level 13 and 17, this increases the amount of Rage you recover to 2 and 3 respectively.
+
+    to
+    > If you or a creature within 5ft of you is the first target of an attack roll, that attack's critical hit threshold is reduced by 1. Additionally, whenever a hostile creature scores a critical hit against you, you recover 1 spent Rage.
+    > At levels 13 and 17, the reduction to the critical hit threshold and the amount of Rage you recover both increase by 1.
+    </details>
+</details>
+
 # 1.5.0 - 2024/10/15
 <details>
 <summary><h2>Added</h2></summary>

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
     - Double Down
 - Condition "Distracted"
     > A distracted creature cannot take reactions.
+- Spellscribing to rules (no changes)
 </details>
 
 <details>

--- a/features/character/aviana/_aviana.mjs
+++ b/features/character/aviana/_aviana.mjs
@@ -1,9 +1,11 @@
 import beastSpirits from "./beastSpirits.mjs"
+import divingStrike from "./divingStrike.mjs";
 import relentlessRage from "./relentlessRage.mjs";
 
 export default {
     registerSubsection() {
         beastSpirits.register();
         relentlessRage.register();
+        divingStrike.register();
     }
 }

--- a/features/character/aviana/beastSpirits.mjs
+++ b/features/character/aviana/beastSpirits.mjs
@@ -1,18 +1,6 @@
 import { MODULE } from "../../../scripts/constants.mjs";
 import { TaliaCustomAPI } from "../../../scripts/api.mjs";
-import { TaliaUtils } from "../../../utils/_utils.mjs";
 const debug = false;
-
-/*
-    - Feature item 'Training': Opens dialog to choose between the available blessings
-
-    - Available blessings are passive feature items on the actor.
-
-    - Once a blessing is chosen, items belonging to other blessings are removed from the actor and items belonging to the chosen blessing are added from the compendium.
-
-
-
-*/
 
 export default {
     register() {
@@ -33,7 +21,7 @@ const blessingsDatabase = {
     },
     "Spirit of the Elk": {
         "Adept Forager": 6,
-        "Stampede": 6,
+        "Battering Ram": 6,
         "Survival Instincts": 10,
         "Unstoppable": 14,
     },
@@ -52,7 +40,7 @@ const blessingsDatabase = {
     },
     "Spirit of the Eagle": {
         "Keen Sight": 6,
-        "Counterstrike": 6,
+        "Billowing Wings": 6,
         "Diving Strike": 10,
         "Double Down": 14,
     },
@@ -95,40 +83,4 @@ async function activateSpirit(actor, chosenSpirit) {
         const created = await Item.createDocuments(itemObjects, {parent: actor});
         if(debug) console.log({created});
     }
-
-    const spiritItem = actor.itemTypes.feat.find(i => i.name === chosenSpirit);
-    TaliaUtils.Helpers.displayItemInfoOnly(spiritItem);
 }
-
-
-
-async function trainingDialog(actor) {
-    if(!actor.name.includes("Aviana")) return;
-    const unlockedSpirits = actor.itemTypes.feat.filter(item => Object.keys(blessingsDatabase).includes(item.name));
-    if(!unlockedSpirits.length) return;
-
-    const options = unlockedSpirits.reduce((acc, e) => acc += `<option value="${e.name}">${e.name}</option>`, "");
-
-    const content = `
-        <form>
-            <span>Choose a blessing.</span>
-            <div class="form-group">
-                <label>Blessing</label>
-                <div class="form-fields">
-                    <select name="blessing">${options}</select>
-                </div>
-            </div>
-        </form>
-    `;
-
-    const choice = await Dialog.prompt({
-        title: "Training",
-        content: content,
-        callback: ([html]) => new FormDataExtended(html.querySelector("form")).object,
-        rejectClose: false,
-    });
-    if(!choice) return;
-
-    return await activateSpirit(actor, choice.blessing);
-}
-

--- a/features/character/aviana/divingStrike.mjs
+++ b/features/character/aviana/divingStrike.mjs
@@ -1,0 +1,278 @@
+// functions are called via item macro chat buttons
+
+import { TaliaCustomAPI } from "../../../scripts/api.mjs";
+
+export default {
+    register() {
+        TaliaCustomAPI.add({ChatButtons_DivingStrike}, "ItemMacros");
+    }
+}
+
+const ChatButtons_DivingStrike = {
+    jump
+}
+
+
+
+
+async function startBorderSequence(token, maxJumpDistInFt, minSpacingInFt) {
+    const ftInGrid = canvas.scene.grid.distance;
+    const tWidthInGU = Math.max(1, token.document.width);   //token width in GU; minimum of 1;
+    const minDistInGU = tWidthInGU / 2 + Math.round(minSpacingInFt / ftInGrid);     //measured from token center
+    const maxDistInGU = tWidthInGU / 2 + Math.round(maxJumpDistInFt / ftInGrid);
+
+    return await new Sequence()
+            .effect()
+                .persist()
+                .name("outerBorderEffect")
+                .atLocation(token)
+                .shape("roundedRect", {
+                    name: "outerRectShape",
+                    radius: 0.5,
+                    lineSize: 4,
+                    lineColor: game.user.color.toString(),
+                    gridUnits: true,
+                    fillAlpha: 0.15,
+                    //fillColor: "",
+                    height: 2 * maxDistInGU,
+                    width: 2 * maxDistInGU,
+                    offset: {
+                        x: - maxDistInGU,
+                        y: - maxDistInGU ,
+                        gridUnits: true
+                    }
+                })
+                .loopProperty("shapes.outerRectShape", "scale.x", {from: 0.995, to: 1.005, duration: 1500, pingPong: true, ease: "easeInOutSine"})
+                .loopProperty("shapes.outerRectShape", "scale.y", {from: 0.995, to: 1.005, duration: 1500, pingPong: true, ease: "easeInOutSine"})
+            .effect()
+                .persist()
+                .name("innerBorderEffect")
+                .atLocation(token)
+                .shape("roundedRect", {
+                    name: "innerRectShape",
+                    radius: 0.5,
+                    lineSize: 4,
+                    lineColor: game.user.color.toString(),
+                    gridUnits: true,
+                    fillAlpha: 0.3,
+                    fillColor: "#fa2511",
+                    height: 2 * minDistInGU,
+                    width: 2 * minDistInGU,
+                    offset: {
+                        x: - minDistInGU,
+                        y: - minDistInGU,
+                        gridUnits: true
+                    }
+                })
+                .loopProperty("shapes.innerRectShape", "scale.x", {from: 0.995, to: 1.005, duration: 1500, pingPong: true, ease: "easeInOutSine"})
+                .loopProperty("shapes.innerRectShape", "scale.y", {from: 0.995, to: 1.005, duration: 1500, pingPong: true, ease: "easeInOutSine"})
+            .play()
+}
+
+async function endBorderSequence() {
+    return await Sequencer.EffectManager.endEffects({ name: "*BorderEffect" });
+}
+
+async function getAndVerifyLocation(token, maxJumpDistInFt, minSpacingInFt) {
+    const tWidthInGU = Math.max(1, token.document.width);   //token width in GU; minimum of 1;
+
+    const location = await Sequencer.Crosshair.show({
+        location: {
+            obj: token,
+            limitMaxRange: maxJumpDistInFt - 1,
+            limitMinRange: minSpacingInFt + 6,
+            showRange: true,
+            wallBehavior: Sequencer.Crosshair.PLACEMENT_RESTRICTIONS.LINE_OF_SIGHT
+        },
+        gridHighlight: true,
+        snap: {
+            position: tWidthInGU % 2 === 0 ? CONST.GRID_SNAPPING_MODES.VERTEX : CONST.GRID_SNAPPING_MODES.CENTER
+        }    
+    });
+    token.control();
+    if(location === false) return null; // false means it's been cancelled so we need to break the loop.
+
+    const col = Sequencer.Crosshair.collect(location);
+    if(!col.length || col[0]._id === token._id) {
+        ui.notifications.info("You need to select a location which is occupied by a token.");
+        return await getAndVerifyLocation(token, maxJumpDistInFt, minSpacingInFt);
+    }
+    return location;
+}
+
+async function updateBabonus(item, pointA, pointB) {
+    //calculate damage
+    const bonusDamageDiceSize = "d6";
+    const path = canvas.grid.measurePath([pointA, pointB], {});
+    const dice = Math.floor(path.distance/10);
+    const damageDiceString = dice ? `${dice}${bonusDamageDiceSize}` : "0";
+
+    // get bonus
+    const col = babonus.getCollection(item);
+    const bonus = col.find(b => b.name === item.name);
+
+    // update if needed
+    if(bonus.bonuses.bonus !== damageDiceString) {
+        await bonus.update({"bonuses.bonus": damageDiceString});
+    }
+    return ui.notifications.info(`Your ${path.distance}ft leap adds ${damageDiceString} damage to the attack.`);
+}
+
+async function jump(token, item) {
+    const maxJumpDistInFt = TaliaCustom.Other.getJumpDistance(token.actor);
+    const minSpacingInFt = 5;
+
+    //get location 
+    startBorderSequence(token, maxJumpDistInFt, minSpacingInFt);    //display the range until a location is chosen or until it's aborted
+    const location = await getAndVerifyLocation(token, maxJumpDistInFt, minSpacingInFt);
+    await endBorderSequence();
+
+    if(!location) return;   //if jump is cancelled
+    const targetPosition = {
+        x: location.x,
+        y: location.y
+    };
+
+    return await Promise.all([
+        updateBabonus(item, token.center, targetPosition),
+        playJumpAnimation(token, targetPosition)
+    ]);
+}
+
+function adjustToTokenScale(token, dist) {
+    const ftInGrid = canvas.scene.grid.distance;    //almost always = 5
+    const tWidth = Math.max(1, token.document.width);    //token width in GU; minimum of 1
+
+    const distInGU =  tWidth / 2 + Math.round(dist / ftInGrid);    //measured from token center
+    return {
+        distanceInGU: distInGU,
+        shape: {
+            height: 2 * distInGU,   //border width/height
+            width: 2 * distInGU,
+            offset: {
+                x: - distInGU,  //border offset
+                y: - distInGU,
+                gridUnits: true
+            }
+        }
+    }
+}
+
+
+
+
+async function displayRange(token, config = {}) {
+    const {
+        maxDist = 20,
+        minDist = 10,
+        animDurationInMs = 10000
+    } = config;
+
+    new Sequence()
+        .effect()
+            .duration(animDurationInMs)
+            .atLocation(token)
+            .shape("roundedRect", {
+                name: "outerRectShape",
+                radius: 0.5,
+                lineSize: 4,
+                lineColor: game.user.color.toString(),
+                gridUnits: true,
+                fillAlpha: 0.15,
+                //fillColor: "#fc8d83",
+                ...adjustToTokenScale(token, maxDist).shape
+            })
+            .loopProperty("shapes.outerRectShape", "scale.x", {from: 0.995, to: 1.005, duration: 1500, pingPong: true, ease: "easeInOutSine"})
+            .loopProperty("shapes.outerRectShape", "scale.y", {from: 0.995, to: 1.005, duration: 1500, pingPong: true, ease: "easeInOutSine"})
+        .effect()
+            .duration(animDurationInMs)
+            .atLocation(token)
+            .shape("roundedRect", {
+                name: "innerRectShape",
+                radius: 0.5,
+                lineSize: 4,
+                lineColor: game.user.color.toString(),
+                gridUnits: true,
+                fillAlpha: 0.3,
+                fillColor: "#fa2511",
+                ...adjustToTokenScale(token, minDist).shape
+            })
+            .loopProperty("shapes.innerRectShape", "scale.x", {from: 0.995, to: 1.005, duration: 1500, pingPong: true, ease: "easeInOutSine"})
+            .loopProperty("shapes.innerRectShape", "scale.y", {from: 0.995, to: 1.005, duration: 1500, pingPong: true, ease: "easeInOutSine"})
+        .play()
+}
+
+
+
+
+async function playJumpAnimation(token, position) {
+    await new Sequence()
+        .canvasPan()
+            .delay(100)
+            .shake({duration: 500, strength: 2, rotation: true, fadeOut:500})
+
+        .effect()
+            .file("jb2a.impact.ground_crack.orange.01")
+            .startTime(300)
+            .scale(0.3)
+            .randomRotation()
+            .atLocation(token)
+            .belowTokens()
+
+        .effect()
+            .file("jb2a.smoke.puff.side.02.white.1")
+            .atLocation(token)
+            .rotateTowards(position)
+            .rotate(180)
+            .belowTokens()
+
+        .animation()
+            .on(token)
+            .opacity(0)
+
+        .effect()   //salto
+            .from(token)
+            .scaleOut(3, 1500, {ease: "easeOutQuint"})
+            .fadeOut(800, {ease: "easeOutQuint"})
+            .rotateTowards(position, { rotate: false })
+            .animateProperty("sprite", "position.x", { from: 0, to: 1, duration: 1250, gridUnits: true, ease: "easeOutQuint"})
+            .waitUntilFinished()
+
+        .animation()
+            .on(token)
+            .teleportTo(position)
+            .snapToGrid()
+
+        .effect()   //queda
+            .from(token)
+            .atLocation(position)
+            .scaleIn(3, 1200, {ease: "easeInCubic"})
+            .fadeIn(600, {ease: "easeInCubic"})
+            .rotateTowards(token, { rotate: false })
+            .animateProperty("sprite", "position.x", { from: 3, to: -0.5, duration: 1250, gridUnits: true, ease: "easeInCubic"})
+            .waitUntilFinished(-50)
+
+        .effect()
+            .file("jb2a.smoke.puff.ring.01.white.1")
+            .randomRotation()
+            .atLocation(position)
+            .belowTokens()
+
+        .effect()
+            .file("jb2a.impact.ground_crack.orange.01")
+            .startTime(300)
+            .randomRotation()
+            .atLocation(position)
+            .belowTokens()
+
+        .canvasPan()
+            .delay(100)
+            .shake({duration: 1200, strength: 3, rotation: true, fadeOut:500})
+        
+        .animation()
+            .delay(50)
+            .on(token)
+            .opacity(1)
+            
+        .play()
+}

--- a/features/shared/commonActions/jump.mjs
+++ b/features/shared/commonActions/jump.mjs
@@ -22,7 +22,8 @@ export default {
 }
 
 class Jump {
-    static getDistance(rollData) {
+    static getDistance(actor) {
+        const rollData = actor.getRollData();
         const acr = Math.max(foundry.utils.getProperty(rollData, "skills.acr.total") ?? 0, 0);
         const ath = Math.max(foundry.utils.getProperty(rollData, "skills.ath.total") ?? 0, 0);
 
@@ -48,7 +49,7 @@ class Jump {
 
     static async itemMacro(item) {
         const rollData = item.actor.getRollData();
-        const jumpDistanceInFt = Jump.getDistance(rollData);
+        const jumpDistanceInFt = Jump.getDistance(item.actor);
     
         const sourceToken = rollData.token;
     

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -62,10 +62,10 @@ Hooks.once("init", () => {
     _items.registerSection();
     _spells.registerSection();
     _features.registerSection();
-    registerHomebrewRules();
+    registerRulePages();
 });
 
-function registerHomebrewRules() {
+function registerRulePages() {
     //  all of the keys have to be lowercase only for some reason!
     CONFIG.DND5E.rules.legres = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.y7XsmDawHmZdSTTR";
     CONFIG.DND5E.rules.alchemy = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.Z0XP4RuNUbFSIMVN";       //also in alchemy.mjs
@@ -74,4 +74,18 @@ function registerHomebrewRules() {
     CONFIG.DND5E.rules.ancientarmor = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.teudeOPJnJzaJQiV";      //also in spellFailureChance.mjs
     CONFIG.DND5E.rules.undoingasurge = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.fXqW6yKBSh1Duwlw";
     CONFIG.DND5E.rules.spellscribing = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.RRUMkplfkv2jAr8s";
+
+    //settlement rules
+    CONFIG.DND5E.rules.settlementauthority = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.CuGAAat2fnLmTJ2i";
+    CONFIG.DND5E.rules.settlementeconomy = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.0kGpBHo50tv7PhmK";
+    CONFIG.DND5E.rules.settlementcommunity = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.YtEe7Nf8q4c5FnW3";
+    CONFIG.DND5E.rules.settlementprogress = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.TjVI03A8GkKvgN73";
+    CONFIG.DND5E.rules.settlementintrigue = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.XBLIJjKNcqCgh24o";
+    CONFIG.DND5E.rules.settlementcapacityandscale = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.O9ONopSI5pf7bZkq";
+    CONFIG.DND5E.rules.settlementsentinels = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.i5xrk1pxNnIoYj3y";
+    CONFIG.DND5E.rules.settlementguilds = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.PBLoOa38RN62j0Qn";
+    CONFIG.DND5E.rules.settlementcommoners = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.QDIzkHKxvfCmpCwS";
+    CONFIG.DND5E.rules.settlementseekers = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.QQEdzklhPjPnSlJm";
+    CONFIG.DND5E.rules.settlementveiled = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.uRbfYgrnFvo1XA4Q";
+    CONFIG.DND5E.rules.settlementbuildings = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.uruo07oEBNb25uEe";
 }

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -73,4 +73,5 @@ function registerHomebrewRules() {
     CONFIG.DND5E.rules.triggeredabilities = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.DCZAvOjR2CqqnEpT";
     CONFIG.DND5E.rules.ancientarmor = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.teudeOPJnJzaJQiV";      //also in spellFailureChance.mjs
     CONFIG.DND5E.rules.undoingasurge = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.fXqW6yKBSh1Duwlw";
+    CONFIG.DND5E.rules.spellscribing = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.RRUMkplfkv2jAr8s";
 }

--- a/utils/_utils.mjs
+++ b/utils/_utils.mjs
@@ -13,10 +13,29 @@ export default {
         TaliaCustomAPI.add(TaliaUtils, "none");
         ItemHookManager.registerManager();
         sizeChange.regsiter();
+        extendStringClass();
     }
 }
 
 export const TaliaUtils = {
     Crosshairs,
     Helpers,
+}
+
+function extendStringClass() {
+    String.prototype.toCamelCase = function() {
+        return this
+            // Insert a space between lowercase and uppercase letters to handle camelCase or PascalCase
+            .replace(/([a-z])([A-Z])/g, '$1 $2')
+            // Split the string by non-alphanumeric characters or inserted spaces
+            .split(/[^a-zA-Z0-9]+/)
+            // Capitalize the first letter of each word except the first one
+            .map((word, index) => 
+                index === 0 
+                    ? word.toLowerCase()
+                    : word.charAt(0).toUpperCase() + word.slice(1)
+            )
+            // Join the words back together
+            .join('');
+    }
 }

--- a/world/_world.mjs
+++ b/world/_world.mjs
@@ -3,6 +3,7 @@ import soulBoundItemProperty from "./soulBoundItemProperty.mjs";
 import spellFailureChance from "./spellFailureChance.mjs";
 import wildMagic from "./wildMagic/wildMagic.mjs";
 import customLimitedUsePeriods from "./customLimitedUsePeriods.mjs";
+import _settlement from "./settlement/_settlement.mjs";
 
 
 export default {
@@ -12,5 +13,6 @@ export default {
         changesToConditions.register();
         spellFailureChance.register();
         customLimitedUsePeriods.register();
+        _settlement.registerSubsection();
     }
 }

--- a/world/changesToConditions.mjs
+++ b/world/changesToConditions.mjs
@@ -5,6 +5,7 @@
 export default {
     register() {
         addChangesToStatusEffects();
+        addNewStatusEffects();
     }
 }
 
@@ -106,3 +107,23 @@ function addChangesToStatusEffects() {
 }
 
 
+function addNewStatusEffects() {
+    const effectsToAdd = {
+        distracted: {
+            label: "Distracted",
+            icon: "TaliaCampaignCustomAssets/c_Icons/svg/distraction.svg",
+            reference: "Compendium.talia-custom.rules.JournalEntry.RZVeB9Toae7IWbzN.JournalEntryPage.5R0uPqr2WgB08C2T",
+        }
+    };
+
+    for(const [k, v] of Object.entries(effectsToAdd)) {
+        CONFIG.statusEffects.push({
+            _id: `dnd5e${k}00000`,
+            id: k, 
+            name: v.label,
+            icon: v.icon,
+            reference: v.reference
+        });
+        CONFIG.DND5E.conditionTypes[k] = v;
+    }
+}

--- a/world/settlement/_settlement.mjs
+++ b/world/settlement/_settlement.mjs
@@ -1,0 +1,7 @@
+import settlement from "./settlement.mjs"
+
+export default {
+    registerSubsection() {
+        settlement.register();
+    }
+}

--- a/world/settlement/settlement.mjs
+++ b/world/settlement/settlement.mjs
@@ -1,0 +1,456 @@
+import { TaliaCustomAPI } from "../../scripts/api.mjs";
+import { MODULE } from "../../scripts/constants.mjs";
+
+export default {
+    register() {
+        TaliaCustomAPI.add({Settlement}, "none");
+    }
+}
+
+
+
+// just use a class to manage the single settlement of Promise
+class Settlement {
+    static flagKey = "settlementFlag";
+
+    // Properties
+    buildings = {
+        /** @type {Map} */
+        constructed: new foundry.utils.Collection(),
+        /** @type {Map} */
+        all: new foundry.utils.Collection(),
+    }
+    name = "Promise";
+    foundingDate = { //Septimus 1st 1497
+        year: 1497,
+        month: 6,
+        day: 0,
+    };
+    attributes = {
+        authority: 0,
+        economy: 0,
+        community: 0,
+        progress: 0,
+        intrigue: 0,
+        capacity: 4,
+    };
+
+    /**
+     * Creates a new Settlement instance
+     * @param {object|string|null} [data] - Initial data for the settlement. Can be an object or JSON string
+     * @throws {Error} If data is a string but contains invalid JSON
+     * @throws {TypeError} If data is neither an object nor a string
+     */
+    constructor(data) {
+        if (data) {
+            if (typeof data === 'string') {
+                try {
+                    const parsed = Settlement.fromJSON(data);
+                    Object.assign(this, parsed);
+                } catch (error) {
+                    throw new Error(`Failed to construct Settlement from JSON string: ${error.message}`);
+                }
+                return;
+            }
+            if (typeof data !== 'object') {
+                throw new TypeError('Settlement constructor data must be an object or JSON string');
+            }
+            Object.assign(this, data);
+        }
+    }
+
+    /**
+     * Converts the Settlement instance to a JSON-serializable object with type information
+     * Handles special data types including Sets, Maps, Collections, and Dates
+     * @returns {object} A plain object representation with type metadata
+     * @throws {Error} If circular references are detected
+     */
+    toJSON() {
+        // Set to track processed objects for circular reference detection
+        const processed = new WeakSet();
+
+        const serialize = (value, path = []) => {
+            // Handle null/undefined
+            if (value == null) return value;
+
+            // Check for circular references in objects
+            if (typeof value === 'object') {
+                if (processed.has(value)) {
+                    throw new Error(`Circular reference detected at path: ${path.join('.')}`);
+                }
+                processed.add(value);
+            }
+
+            try {
+                // Handle Date objects
+                if (value instanceof Date) {
+                    if (isNaN(value.getTime())) {
+                        throw new Error(`Invalid Date at path: ${path.join('.')}`);
+                    }
+                    return { __type: 'Date', value: value.toISOString() };
+                }
+
+                // Handle Sets
+                if (value instanceof Set) {
+                    return {
+                        __type: 'Set',
+                        value: Array.from(value).map((v, i) => serialize(v, [...path, `Set[${i}]`]))
+                    };
+                }
+
+                // Handle Maps and Collections
+                if (value instanceof Map) {
+                    return {
+                        __type: value.constructor.name,
+                        value: Array.from(value.entries()).map(([k, v], i) => [
+                            serialize(k, [...path, `${value.constructor.name}[${i}].key`]),
+                            serialize(v, [...path, `${value.constructor.name}[${i}].value`])
+                        ])
+                    };
+                }
+
+                // Handle Arrays
+                if (Array.isArray(value)) {
+                    return value.map((v, i) => serialize(v, [...path, i]));
+                }
+
+                // Handle Objects
+                if (typeof value === 'object') {
+                    const obj = {};
+                    for (const [key, val] of Object.entries(value)) {
+                        obj[key] = serialize(val, [...path, key]);
+                    }
+                    return obj;
+                }
+
+                // Return primitive values directly
+                return value;
+
+            } catch (error) {
+                // Add path information to error message if not already present
+                if (!error.message.includes('path:')) {
+                    error.message += ` at path: ${path.join('.')}`;
+                }
+                throw error;
+            }
+        };
+        return serialize(this);
+    }
+
+    /**
+     * Creates a Settlement instance from a JSON string or object
+     * @param {string|object} json - JSON string or pre-parsed object to deserialize
+     * @returns {Settlement} A new Settlement instance
+     * @throws {SyntaxError} If the JSON string is malformed
+     * @throws {TypeError} If the deserialized data contains invalid type markers
+     * @throws {Error} If the data structure is invalid or contains unknown type markers
+     * @static
+     */
+    static fromJSON(json) {
+        // Parse JSON string if necessary
+        let data;
+        try {
+            data = typeof json === 'string' ? JSON.parse(json) : json;
+        } catch (error) {
+            throw new SyntaxError(`Invalid JSON string: ${error.message}`);
+        }
+
+        const deserialize = (value, path = []) => {
+            try {
+                // Handle null/undefined
+                if (value == null) return value;
+
+                // Handle special types
+                if (value && typeof value === 'object' && value.__type) {
+                    switch (value.__type) {
+                        case 'Set':
+                            if (!Array.isArray(value.value)) {
+                                throw new TypeError('Set value must be an array');
+                            }
+                            return new Set(value.value.map((v, i) => 
+                                deserialize(v, [...path, `Set[${i}]`])));
+                            
+                        case 'Map':
+                        case 'Collection':
+                            if (!Array.isArray(value.value)) {
+                                throw new TypeError(`${value.__type} value must be an array of entries`);
+                            }
+                            const entries = value.value.map(([k, v], i) => [
+                                deserialize(k, [...path, `${value.__type}[${i}].key`]),
+                                deserialize(v, [...path, `${value.__type}[${i}].value`])
+                            ]);
+                            return value.__type === 'Collection' 
+                                ? new foundry.utils.Collection(entries)
+                                : new Map(entries);
+                            
+                        case 'Date':
+                            const date = new Date(value.value);
+                            if (isNaN(date.getTime())) {
+                                throw new TypeError('Invalid Date value');
+                            }
+                            return date;
+                            
+                        default:
+                            throw new Error(`Unknown type marker: ${value.__type}`);
+                    }
+                }
+
+                // Handle Arrays
+                if (Array.isArray(value)) {
+                    return value.map((v, i) => deserialize(v, [...path, i]));
+                }
+
+                // Handle Objects
+                if (typeof value === 'object') {
+                    const obj = {};
+                    for (const [key, val] of Object.entries(value)) {
+                        obj[key] = deserialize(val, [...path, key]);
+                    }
+                    return obj;
+                }
+
+                // Return primitive values directly
+                return value;
+
+            } catch (error) {
+                // Add path information to error message if not already present
+                if (!error.message.includes('path:')) {
+                    error.message += ` at path: ${path.join('.')}`;
+                }
+                throw error;
+            }
+        };
+
+        try {
+            return new Settlement(deserialize(data));
+        } catch (error) {
+            throw new Error(`Failed to deserialize Settlement: ${error.message}`);
+        }
+    }
+
+    static async saveToFlag() {
+        const data = JSON.stringify(this);
+        if(!game.user.isGM) throw new Error("Only GM can set world flags.")
+        return await game.world.setFlag(MODULE.ID, Settlement.flagKey, data);
+    }
+
+
+    init() {
+        let flagData = Settlement.loadFromFlagData() ?? {};
+
+    }
+
+
+    static loadFromFlagData() {
+        return game.world.getFlag(MODULE.ID, Settlement.flagKey) ?? null;
+    }
+
+    static async setFlagData(data) {
+        if(!game.user.isGM) throw new Error("Only GM can set world flags.")
+        return await game.world.setFlag(MODULE.ID, Settlement.flagKey, data);
+    }
+
+    async importBuildingsFromJson() {
+        const {StringField} = foundry.data.fields;
+        const {DialogV2} = foundry.applications.api;
+
+        const stringPart = new StringField({
+            label: "Input JSON"
+        }).toFormGroup({},{name: "jsonString"}).outerHTML;
+
+        const input = await DialogV2.prompt({
+            content: stringPart,
+            ok: {
+                callback: (event, button) => new FormDataExtended(button.form).object
+            },
+            rejectClose: false,
+        });
+        if(!input) return;
+        const inputObj = JSON.parse(input.jsonString)
+
+        for(const buildingData of Object.values(inputObj)) {
+            const building = new Building(buildingData);
+            this.buildings.all.set(building.id, building);        
+        }
+    }
+} 
+
+class Building {
+    constructor({id, name, description, scale, attributes, requirements, specialEffects}) {
+        this.id = id;
+        this.name = name;
+        this.description = description,
+        this.scale = scale;
+        this.attributes = {
+            authority: attributes.authority || 0,
+            economy: attributes.economy || 0,
+            community: attributes.community || 0,
+            progress: attributes.progress || 0,
+            intrigue: attributes.intrigue || 0,
+        };
+        this.requirements = requirements || undefined;
+        this.specialEffects = specialEffects || undefined;
+    }
+    
+}
+
+async function addBuildingsDataJson() {
+    const {StringField} = foundry.data.fields;
+    const {DialogV2} = foundry.applications.api;
+
+    const stringPart = new StringField({
+        label: "Input JSON"
+    }).toFormGroup({},{name: "jsonString"}).outerHTML;
+
+    const input = await DialogV2.prompt({
+        content: stringPart,
+        ok: {
+            callback: (event, button) => new FormDataExtended(button.form).object
+        },
+        rejectClose: false,
+    });
+    if(!input) return;
+    const inputObj = JSON.parse(input.jsonString)
+
+    
+    console.log(inputObj);
+}
+
+
+async function addBuildingToJournal(journalName = "Promise") {
+    //get buildings from rules entry
+    const rulePageUuid = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.uruo07oEBNb25uEe";
+    const rulePage = await fromUuid(rulePageUuid);
+
+    //get substrings
+    const subStrings = rulePage.text.content.split(/(?=<h3>)/);
+
+    //get the parsed building data for each building
+    const buildings = {};
+    for(const substr of subStrings) {
+
+    }
+
+    //transform to object
+
+    for(const substr of subStrings) {
+        const titleMatch = substr.match(/<h3>(.*?)<\/h3>/);
+        if(titleMatch) {
+            const title = titleMatch[1];
+            buildings[title] = substr
+        }
+    }
+
+    //choose the building
+    const choice = await (async () => {
+        const choices = Object.keys(buildings).reduce((acc, curr) => {
+            acc[curr] = curr;
+            return acc;
+        }, {});
+        const selectBuilding = new foundry.data.fields.StringField({
+            label: "Select a building",
+            required: true,
+            choices: choices
+        }).toFormGroup({}, {name: "building", choices}).outerHTML;
+        return await foundry.applications.api.DialogV2.prompt({
+            window: {
+                title: "Add Building"
+            },
+            content: `<fieldset>${selectBuilding}</fieldset>`,
+            modal: true,
+            rejectClose: false,
+            ok: {
+                label: "Ok",
+                callback: (event, button) => new FormDataExtended(button.form).object,
+            },
+        });
+    })();
+    if(!choice) return;
+
+    //get the parsed building data;
+
+    //get the journal & page
+    const journal = game.journal.getName(journalName);
+    const buildingsPage = journal.pages.contents.find(e => e.name === "Buildings");
+    
+    //if the building is not yet built, add it to the journal
+    if(!buildingsPage.text.content.includes(buildings[choice.building])) {
+        await buildingsPage.update({"text.content": buildingsPage.text.content + buildings[choice.building]});
+    }
+
+    
+}
+
+/**
+ * Parses an HTML string representing a building and extracts relevant data such as name, description, effects, and special effects.
+ * 
+ * @param {string} htmlString - The HTML string containing building data, including an <h3> tag for the name, a <p> tag for the description, and <li> elements for effects and special effects.
+ * 
+ * @returns {Object} - An object containing the parsed building data.
+ * @returns {string} return.name - The name of the building, extracted from the <h3> tag.
+ * @returns {string} return.description - The description of the building, extracted from the first <p> tag.
+ * @returns {Object} return.effects - An object containing the effects of the building. Each effect (authority, economy, community, progress, intrigue) is a key, with a number as the value.
+ * @returns {number} return.effects.authority - The value of the authority effect, defaulting to 0 if not specified.
+ * @returns {number} return.effects.economy - The value of the economy effect, defaulting to 0 if not specified.
+ * @returns {number} return.effects.community - The value of the community effect, defaulting to 0 if not specified.
+ * @returns {number} return.effects.progress - The value of the progress effect, defaulting to 0 if not specified.
+ * @returns {number} return.effects.intrigue - The value of the intrigue effect, defaulting to 0 if not specified.
+ * @returns {string|null} return.specialEffects - A string describing the special effects of the building, or null if no special effects are present.
+ */
+function parseBuildingData(htmlString) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(htmlString, "text/html");
+
+    const name = doc.querySelector("h3")?.textContent || "";
+    const description = doc.querySelector("p")?.textContent || "";
+
+
+    // Set default values for all effects attributes
+    const effects = {
+        authority: 0,
+        economy: 0,
+        community: 0,
+        progress: 0,
+        intrigue: 0
+    };
+    
+    // Find all <li> elements
+    const listItems = doc.querySelectorAll('li');
+    
+    // Loop through the <li> elements and find the effects and special effects
+    let specialEffects = '';
+    listItems.forEach(li => {
+        const strongTag = li.querySelector('strong');
+        if (strongTag) {
+            const strongText = strongTag.textContent.trim();
+        
+            // Check if this is the "Effects" line
+            if (strongText.includes('Effects')) {
+                const effectsText = li.textContent;
+                
+                // Regular expression to find the numbers associated with each effect
+                const effectMatches = effectsText.match(/([+-]?\d+)\s*(Authority|Economy|Community|Progress|Intrigue)/gi);
+                
+                // If there are matches, update the effects object
+                if (effectMatches) {
+                    effectMatches.forEach(match => {
+                        const [ , value, attribute ] = match.match(/([+-]?\d+)\s*(Authority|Economy|Community|Progress|Intrigue)/i);
+                        effects[attribute.toLowerCase()] = parseInt(value, 10);  // Update the effects object
+                    });
+                }
+            }
+            
+            // Check if this is the "Special Effects" line
+            if (strongText.includes('Special Effects')) {
+                specialEffects = li.textContent.replace(/.*Special Effects:\s*/, '').trim();
+            }
+        }
+    });
+
+    return {
+        name,
+        description,
+        effects,
+        specialEffects: specialEffects || null  // Return null if no special effects found
+    };
+}


### PR DESCRIPTION
<details>
<summary><h2>Added</h2></summary>

- 'Fixed' Necklace of Mighty Breath by adding an upgraded version.
- Spirit of the Eagle features
    - Spirit of the Eagle
    - Keen Sight
    - Billowing Wings
    - Diving Strike
    - Double Down
- Condition "Distracted"
    > A distracted creature cannot take reactions.
- Spellscribing to rules (no changes)
</details>

<details>
<summary><h2>Changed</h2></summary>

- Activating (changing to) a new Beast Spirit can now cause a wild magic surge.
- Spirit of the Bear: Reduced the duration of the Taunted effect from Savage Taunt and Compelled Duel from three turns to two turns.
-   <details>
    <summary>Spirit of the Elk</summary>

    -   Adept Forager (unchanged)
    -   <details>
        <summary>Stampede -> Battering Ram</summary>

        from
        > As a bonus action, you charge forward in a straight line up to a distance equal to your maximum jump distance.
        > You pass through creatures in your path, pushing them backward in the direction of your charge. The distance each creature is pushed is equal to the distance you can shove a creature of that size.
        > Colliding with a creature does not slow or stop your charge.

        to
        > When you take the Attack action on your turn, you can replace one of your attacks with a special charge attack.
        >
        > You move up to 50 feet in a straight line that is 5 feet wide, stopping when you hit the first creature in your path. The creature must make a Strength saving throw (DC = 8 + your Strength modifier + your Constitution modifier + your proficiency bonus). On a failed save, the creature takes 1d12 + your Strength modifier bludgeoning damage and is knocked back a distance equal to how far you charged before hitting it (to a maximum of 50 feet).
        >
        > If the creature is knocked back into another creature or a solid object, additional effects occur based on the distance it was knocked back:
        >
        > - Less than 30 feet: The creature is distracted until the start of its next turn.
        > - 30 to 40 feet: The creature is restrained until the end of its next turn.
        > - More than 40 feet: The creature is paralyzed until the end of its next turn.
        >
        > If the creature collides with another creature, both creatures suffer the same effect.
        </details>
    
    -   <details>
        <summary>Survival Instincts</summary>

        from
        > When you use Stampede, you gain an amount of temporary hit points equal to your barbarian level.
        > Additionally, the distance you're able to shove a creature is increased by 10ft.

        to
        > Your walking speed is increased by 20ft, you have a 1d6 bonus to your initiative rolls and, as long as you aren't incapacitated, you cannot be surprised.
        > Using Battering Ram grants you an amount of temporary hit points equal to your barbarian level.
        </details>
    
    -   <details>
        <summary>Unstoppable</summary>

        from
        > As long as you're not incapacitated, your movement speed cannot be reduced.
        > 
        > Additionally, when using Stampede, you can charge through and break objects, such as walls, up to 5ft thick.
        > Stampede can also charge through magical barriers by succeeding on a Strength saving throw against the caster's spell save DC. If the barrier requires concentration to sustain, breaking through it immediately ends the caster's concentration.

        to
        > As long as you're not incapacitated, your movement speed cannot be reduced and you are immune to being frightened, restrained, grappled, or knocked prone..
        >
        > Additionally, you can use Battering Ram to charge through and break solid objects, such as walls, up to 5ft thick.
        > You can also charge through and create holes in magical barriers this way if you succeed on a Strength saving throw against the caster's spell save DC. If the barrier requires concentration to maintain, breaking through it immediately ends the caster's concentration on the barrier.
        </details>
    </details>
</details>

<details>
<summary><h2>Fixed</h2></summary>

- Feral Instinct now correctly grants advantage on automatic initiative rolls
- Applying the incapacitated status no longer throws an error (fixed in DAE 11.3.65)
- Continual Flame Gem no longer duplicates auras.
- Beast Spirit Blessing activations appearing twice in the chat log.
-   <details>
    <summary>Barbaric Critical</summary>

    Fixed the deleted effect and clarified the wording of the ability so it better reflects the implementation.

    from
    > Attack rolls against you or creatures within 5ft of you have their critical hit threshold reduced by 1. When you reach level 13 and 17, this increases to a reduction in critical hit threshold of 2 and 3 respectively.
    >
    > Additionally whenever a hostile creature scores a critical hit against you, you recover 1 spent Rage. When you reach level 13 and 17, this increases the amount of Rage you recover to 2 and 3 respectively.

    to
    > If you or a creature within 5ft of you is the first target of an attack roll, that attack's critical hit threshold is reduced by 1. Additionally, whenever a hostile creature scores a critical hit against you, you recover 1 spent Rage.
    > At levels 13 and 17, the reduction to the critical hit threshold and the amount of Rage you recover both increase by 1.
    </details>
</details>