### PR TITLE
1.7.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,43 @@
+# 1.7.0 - 2024/10/29
+
+<details>
+<summary><h2>Added</h2></summary>
+
+- Condition "Dazed"
+    > A dazed creature can only do one of the following things on their turn: move, use an action, or use a bonus action. If a creature becomes dazed during their turn, their turn ends. The cure ailment power, lesser restoration spell, and greater restoration spell remove the dazed condition. At the GM's discretion, other powers, spells, or effects might also remove the dazed condition.
+    >
+    > When a dazed creature is affected by a spell or effect that gives them an extra action on their turn (like the haste spell or the fighter's Action Surge feature), they can still take this extra action, in addition to the movement, action, or bonus action allowed by the dazed condition.
+    > 
+    > Some creatures in this book have immunity to the dazed condition. At the GM's discretion, a creature published in the core rules or another supplement who has immunity to the paralyzed or stunned condition also has immunity to the dazed condition.
+- Item "Abyssal Nail Polish"
+- Item "Voidborn Explorer's Spellbook"
+
+-   <details>
+    <summary>Spells</summary>
+
+    - Call of the Void
+    - Legend Lore
+    - Forbiddance
+    - Word of Recall
+    - Foresight
+    - Sign of Sanctuary
+    </details>
+- GM Macro `pcItemsToJSON` - used to update the character website
+</details>
+
+<details>
+<summary><h2>Changed</h2></summary>
+
+- Formatting of spell gem descriptions (no functionality change)
+</details>
+
+<details>
+<summary><h2>Fixed</h2></summary>
+
+- Spellbooks once again have the equipment type 'spellbook'
+- Custom conditions are now implemented correctly and should no longer throw errors when applied via the character sheet.
+</details>
+
 # 1.6.0 - 2024/10/22
 
 <details>

--- a/features/professions/spellscribing/SpellGem.mjs
+++ b/features/professions/spellscribing/SpellGem.mjs
@@ -16,7 +16,7 @@ export async function createSpellGem(actor, chosenArgs) {
 
     //fixes after creating the scroll but before creating the actual spell gem on the actor
     foundry.utils.mergeObject(workingObj, {
-        "system.description.value": `${descFixes(chosenArgs)}${workingObj.system.description.value}`,
+        "system.description.value": `${chosenArgs.isTrigger ? `<p><strong>Trigger: </strong>${chosenArgs.triggerConditions}</p><hr>` : ""}${workingObj.system.description.value}`,
         "system.properties": ["mgc"],
     });
     
@@ -61,27 +61,4 @@ function getChanges(actor, chosenArgs) {
     }
 
     return changes;
-}
-
-
-function descFixes(chosenArgs) {
-    //fix description
-    const triggerAdd = chosenArgs.isTrigger ? `
-            <tr>
-                <td>
-                    <p>${chosenArgs.triggerConditions}</p>
-                </td>
-            </tr>` : "";
-    
-    const spellLevelText = CONFIG.DND5E.spellLevels[chosenArgs.selectedSpellSlotLevel];
-    return `<table>
-        <tbody>
-            <tr>
-                <td>
-                    <p style="text-align: center; font-weight: bold;">${spellLevelText}</p>
-                </td>
-            </tr>
-            ${triggerAdd}
-        </tbody>
-    </table>`;
 }

--- a/gmMacros/_gmMacros.mjs
+++ b/gmMacros/_gmMacros.mjs
@@ -1,9 +1,11 @@
 import playerInspirations from "./playerInspirations.mjs"
 import restPrompt from "./restPrompt.mjs";
+import pcItemsToJSON from "./pcItemsToJSON.mjs"
 
 export default {
     registerSection() {
         playerInspirations.register();
         restPrompt.register();
+        pcItemsToJSON.register();
     }
 }

--- a/gmMacros/pcItemsToJSON.mjs
+++ b/gmMacros/pcItemsToJSON.mjs
@@ -1,0 +1,67 @@
+export default {
+    register() {
+        TaliaCustomAPI.add({pcItemsToJSON: actorItemsToClipboard}, "GmMacros");
+    }
+}
+
+/*  get item info:
+
+    All
+    - Name
+    - Description
+
+    items
+    - quantity
+    - attunement
+    - type & subtype
+
+    features
+    - requirements
+
+    spell
+    - spell level
+    - spell school
+    - spell range
+*/
+
+async function actorItemsToClipboard() {
+    if(!game.user.isGM) return;
+    const pcNames = ["Aviana Winterwing", "Fearghas MacAllistar", "Plex", "Shalkoc Zornax"];
+    const allowedItemTypes = ["consumable", "container", "equipment", "feat", "loot", "spell", "tool", "weapon"];
+
+    let actorItems = {};
+    for(let actorName of pcNames) {
+        const workingActor = game.actors.getName(actorName, {strict: true});
+        actorItems[actorName] = workingActor.items 
+            .filter(i => allowedItemTypes.includes(i.type))
+            .map(i => {
+                return {
+                    name: i.name,
+                    itemType: i.type,
+                    description: i.system.description.value,
+                    attunement: i.system.attunement,
+                    quantity: i.system.quantity,
+                    requirements: i.system.requirements,
+
+                    typeLabel: i.system.type?.label,
+                    subType: i.system.type?.subtype,
+                    spellLevel: i.type === "spell" ? i.labels.level : null,
+                    spellRange: i.type === "spell" ? i.labels.range : null,
+                    spellSchool: i.type === "spell" ? i.labels.school : null,
+                }
+            });
+    }
+
+    const jsonString = JSON.stringify(actorItems, null, 2);
+
+    console.log(jsonString);
+
+    try {
+        await navigator.clipboard.writeText(jsonString);
+        alert("JSON copied to clipboard!");
+    } catch (err) {
+        console.error("Failed to copy: ", err);
+    }
+
+    return;
+}

--- a/utils/spellbookManager.mjs
+++ b/utils/spellbookManager.mjs
@@ -11,6 +11,10 @@ import { MODULE } from "../scripts/constants.mjs";
 
 export default {
     register() {
+
+        CONFIG.DND5E.equipmentTypes.spellbook = CONFIG.DND5E.miscEquipmentTypes.spellbook = "Spellbook";
+
+
         Hooks.on("talia-custom.postEquip", async (item) => {
             if(!Spellbook.isSpellbook(item)) return;
             return await new Spellbook(item).addSpellsToActor();

--- a/world/changesToConditions.mjs
+++ b/world/changesToConditions.mjs
@@ -111,17 +111,23 @@ function addNewStatusEffects() {
     const effectsToAdd = {
         distracted: {
             label: "Distracted",
-            icon: "TaliaCampaignCustomAssets/c_Icons/svg/distraction.svg",
+            img: "TaliaCampaignCustomAssets/c_Icons/svg/distraction.svg",
             reference: "Compendium.talia-custom.rules.JournalEntry.RZVeB9Toae7IWbzN.JournalEntryPage.5R0uPqr2WgB08C2T",
+        },
+        dazed: {
+            label: "Dazed",
+            img: "TaliaCampaignCustomAssets/c_Icons/svg/dazed.svg",
+            reference: "Compendium.talia-custom.rules.JournalEntry.RZVeB9Toae7IWbzN.JournalEntryPage.RlGakadjBANEe7Vc",
         }
     };
 
+    
     for(const [k, v] of Object.entries(effectsToAdd)) {
         CONFIG.statusEffects.push({
-            _id: `dnd5e${k}00000`,
             id: k, 
+            _id: `dnd5e${k}`.padEnd(16, '0'),    //id must be 16 characters long,
             name: v.label,
-            icon: v.icon,
+            img: v.img,
             reference: v.reference
         });
         CONFIG.DND5E.conditionTypes[k] = v;


### PR DESCRIPTION
<details>
<summary><h2>Added</h2></summary>

- Condition "Dazed"
    > A dazed creature can only do one of the following things on their turn: move, use an action, or use a bonus action. If a creature becomes dazed during their turn, their turn ends. The cure ailment power, lesser restoration spell, and greater restoration spell remove the dazed condition. At the GM's discretion, other powers, spells, or effects might also remove the dazed condition.
    >
    > When a dazed creature is affected by a spell or effect that gives them an extra action on their turn (like the haste spell or the fighter's Action Surge feature), they can still take this extra action, in addition to the movement, action, or bonus action allowed by the dazed condition.
    > 
    > Some creatures in this book have immunity to the dazed condition. At the GM's discretion, a creature published in the core rules or another supplement who has immunity to the paralyzed or stunned condition also has immunity to the dazed condition.
- Item "Abyssal Nail Polish"
- Item "Voidborn Explorer's Spellbook"

-   <details>
    <summary>Spells</summary>

    - Call of the Void
    - Legend Lore
    - Forbiddance
    - Word of Recall
    - Foresight
    - Sign of Sanctuary
    </details>
- GM Macro `pcItemsToJSON` - used to update the character website
</details>

<details>
<summary><h2>Changed</h2></summary>

- Formatting of spell gem descriptions (no functionality change)
</details>

<details>
<summary><h2>Fixed</h2></summary>

- Spellbooks once again have the equipment type 'spellbook'
- Custom conditions are now implemented correctly and should no longer throw errors when applied via the character sheet.
</details>