### PR TITLE
1.9.0 commit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,93 @@
+# 1.9.0 - 2024/11/12
+
+<details>
+<summary><h2>Added</h2></summary>
+
+- Plex Level 12
+    - HD roll: 5
+    - (ASI) +2 INT
+
+-   <details>
+    <summary>Items</summary>
+
+    - Ioun Stone, Language Knowledge
+    - Conch of Teleportation
+    - Amulet of Proof against Detection and Location
+    - Hoarfrost Shield
+    - Bottle of Bagiennik Snot
+    </details>
+
+-   <details>
+    <summary>Spells</summary>
+
+    - Temporal Shunt
+    - Gravity Fissure
+    - Chain Lightning
+    - Otiluke's Freezing Sphere
+    - Curse of Biting Cold
+    - Vortex Swap
+    - Darkness
+    </details>
+
+-   <details>
+    <summary>Rule: Alternate Skill Checks</summary>
+
+    > Whenever you’re asked to make a skill check outside of combat, you may ask the DM if you can use a different skill by explaining how your character would approach the challenge. This can be expressed in whatever way you want - whether through description, narration, or in-character acting. The DM will consider your explanation and decide if the substitution is appropriate, and may adjust the difficulty (DC) of the check to reflect the nature of using the alternative skill.
+    > 
+    > Example Scenario: Imagine your ship has just sunk, and you're asked to make an Athletics (Strength) check to swim to the shore you can see in the distance. Depending on your character’s skills, you might approach this task differently. Here are a few examples for potential substitutions:
+    > 
+    > - Animal Handling (Wisdom): You recall seeing dolphins earlier and attempt to encourage them to guide you to shore.
+    > - Nature (Intelligence): You’ve read about ocean currents and use this knowledge to align yourself with a helpful current.
+    > - Survival (Wisdom): Having survived similar dangers, you focus on staying calm and moving efficiently.
+    > - Performance (Charisma): You draw from water ballet skills you once learned to impress a merfolk, moving gracefully and efficiently through the waves.
+    > 
+    > Remember, creative substitutions are encouraged to enrich gameplay and give your character unique ways to face challenges, but they don’t guarantee success or a reduced difficulty.
+    </details>
+
+-   <details>
+    <summary>Random Tables</summary>
+
+    - Props - Settlements
+    - Props - Nature
+    </details>
+- GmMacro `rest()` to choose a rest type and rest the actors of all selected tokens.
+- Implemented damage absorption.
+</details>
+
+<details>
+<summary><h2>Changed</h2></summary>
+
+-   <details>
+    <summary>Resting</summary>
+
+    - Rests are now initiated by the GM.
+    - Added rest type "extended rest" which lasts for 2 weeks.
+    - Features which are used during the rest should now be used manually after the rest is completed. Of course they can just be roleplayed as being used during the rest itself, this is purely a mechanical change.
+    </details>
+
+-   <details>
+    <summary>Chef Feat & Cooking</summary>
+
+    - Remade the UI and workflow for Cooking
+    - No longer initiates the rest.
+    - Each serving now requires 1 food and (optionally) 1 spice.
+    </details>
+</details>
+
+<details>
+<summary><h2>Fixed</h2></summary>
+
+- Items which roll to regain their expended uses now do so automatically again. This happens only after taking a rest and doesn't work for all rest types. (WIP)
+- Error when a non-actor combatant was present during a combatTurnChange event.
+</details>
+
+<details>
+<summary><h2>Removed Modules</h2></summary>
+
+- Monk's Little Details
+- Monk's Token Bar (Replaced the movement restriction in combat with custom code)
+</details>
+
 # 1.8.0 - 2024/11/05
 
 <details>

--- a/gmMacros/_gmMacros.mjs
+++ b/gmMacros/_gmMacros.mjs
@@ -2,6 +2,7 @@ import playerInspirations from "./playerInspirations.mjs"
 import restPrompt from "./restPrompt.mjs";
 import pcItemsToJSON from "./pcItemsToJSON.mjs"
 import monsterAttackDescriptionGen from "./monsterAttackDescriptionGen.mjs";
+import restManager from "./restManager.mjs"
 
 export default {
     registerSection() {
@@ -9,5 +10,6 @@ export default {
         restPrompt.register();
         pcItemsToJSON.register();
         monsterAttackDescriptionGen.register();
+        restManager.register();
     }
 }

--- a/gmMacros/restManager.mjs
+++ b/gmMacros/restManager.mjs
@@ -1,0 +1,282 @@
+import { TaliaCustomAPI } from "../scripts/api.mjs";
+export default {
+    register() {
+        RestManager.addExtendedRestToConfig();
+        TaliaCustomAPI.add({rest: RestManager.rest}, "GmMacros");
+    }
+}
+
+class RestManager {
+    /*----------------------------------------------------------------------------
+                    Static Methods            
+    ----------------------------------------------------------------------------*/
+
+    /**
+     * Adds extended rest duration to CONFIG.DND5E
+     */
+    static addExtendedRestToConfig() {
+        const minutesInADay = 24 * 60;    
+        CONFIG.DND5E.restTypes.extended = {
+            duration: {
+                normal: minutesInADay * 14,     // 2 weeks
+                gritty: minutesInADay * 60,     // 2 months (60 days in Talian Calendar)
+                epic: minutesInADay,            // 1 day
+            }
+        };
+    }
+
+    // only method accessible from through the api; handles the entire resting workflow on the GM's side
+    static async rest() {
+        if(!game.user.isGM) throw new Error("Only the GM client can use this class.");
+
+        const restManager = new RestManager()
+            .setRestingActors();
+        await restManager.configureRestOptions();
+        return await restManager._rest();
+    }
+
+    /*----------------------------------------------------------------------------
+                    Instanced Properties            
+    ----------------------------------------------------------------------------*/
+
+    /** @type {Actor5e[]}  Array of resting actors with unique uuids. */
+    restingActors = [];
+
+    /**
+     * @type {Object | null}
+     * @property {boolean = false} isInstantRest   - Is this rest instant (= no time passing)
+     * @property {string} restType                 - One of the keys of CONFIG.DND5E.restTypes
+     */
+    restOptions = null;
+
+    /*----------------------------------------------------------------------------
+                    Instanced Methods            
+    ----------------------------------------------------------------------------*/
+
+    /**
+     * Sets the actors of currently controlled tokens as resting actors.
+     * Avoids duplicates if there's multiple tokens linked to the same actor.
+     * @returns {this}
+     */
+    setRestingActors() {
+        const addedActorUuids = new Set();
+        this.restingActors = canvas.tokens.controlled
+            .map(t => t.actor)
+            .filter(a => {
+                if(addedActorUuids.has(a.uuid)) return false;   //duplicate, so skip
+                addedActorUuids.add(a.uuid);
+                return true;
+            });
+        return this;
+    }
+    
+    /**
+     * Lets the GM configure rest options via a dialog.
+     * @returns {Promise<this>}
+     */
+    async configureRestOptions() {
+        const {StringField, BooleanField} = foundry.data.fields;
+        const {DialogV2} = foundry.applications.api;
+
+        const restTypeField = new StringField({
+            label: "Rest Type",
+            choices: Object.keys(CONFIG.DND5E.restTypes).reduce((acc, k) => {
+                acc[k] = k;
+                return acc;
+            },{}),
+            required: true,
+        }).toFormGroup({},{name: "restType"}).outerHTML;
+
+        const hoursPassingField = new BooleanField({
+            label: "Is instant rest?",
+        }).toFormGroup({},{name: "isInstantRest"}).outerHTML;
+
+        this.restOptions = await DialogV2.prompt({
+            window: { title: "Rest Options" },
+            content: restTypeField+hoursPassingField,
+            ok: {
+                callback: (_, button) => new FormDataExtended(button.form).object,
+            },
+            rejectClose: false,
+        });
+        return this;
+    }
+
+    /**
+     * Rests each actor and passes time.
+     * @returns {Promise<Object[]>} An array of objects containing the results of the rest for each actor.
+     */
+    async _rest() {
+        //validate rest
+        if(this.restOptions === null 
+            || typeof this.restOptions.restType !== "string" 
+            || typeof this.restOptions.isInstantRest !== "boolean"
+            || this.restingActors.length <= 0
+        ) return null;
+
+
+        //calculate time and new day
+        const restDuration = CONFIG.DND5E.restTypes[this.restOptions.restType]?.duration?.[game.settings.get("dnd5e", "restVariant")];
+        const beforeDate = SimpleCalendar.api.currentDateTime();
+        const isNewDay = restDuration >= 24 * 60 ? true    //if the duration is more than a day, it's obviously a new day
+            : (beforeDate.hour * 60 + beforeDate.minute + restDuration) > 24 * 60;  //if the number of minutes in the current day + the rest duration is larger than 24 hours in minutes, it's a new day
+
+        //create the rest config
+        const dnd5eRestConfig = {
+            dialog: false,
+            chat: false,
+            duration: CONFIG.DND5E.restTypes[this.restOptions.restType]?.duration?.[game.settings.get("dnd5e", "restVariant")],
+            newDay: isNewDay,
+            advanceTime: !this.restOptions.isInstantRest,
+            autoHD: false,
+        };
+
+        //let each actor rest
+        const promises = [];
+        for(let actor of this.restingActors) {
+            promises.push(this._restSingleActor(actor, dnd5eRestConfig));
+        }
+        return await Promise.all(promises);
+    }
+
+    /**
+     * Rests a single actor.
+     * @param {Actor5e} actor 
+     * @param {import("../system/dnd5e/dnd5e.mjs").RestConfiguration} config 
+     * @returns {Promise<Object>}   Object containing Actor, Rest Result, and ChatMessage (only for normal rest variant setting).
+     */
+    async _restSingleActor(actor, config) {
+        let result;
+        if(this.restOptions.restType === "extended") {
+            result = await RestManager.extendedRest(actor, config);
+        } else if(this.restOptions.restType === "short") {
+            result = await actor.shortRest(config);
+        } else {
+            result = await actor.longRest(config);
+        }
+        if(game.settings.get("dnd5e", "restVariant") !== "normal") return {actor, result};
+
+        let flavor;
+        let messagePart;
+        if(this.restOptions.restType === "short") {
+            flavor = "Short Rest (1 hour)";
+            messagePart = "a short rest.";
+        } else if (this.restOptions.restType === "long") {
+            flavor = "Long Rest (8 hours)";
+            messagePart = "a long rest.";
+        } else {
+            flavor = "Extended Rest (2 weeks)";
+            messagePart = "an extended rest.";
+        }
+
+        let chatData = {
+            user: game.user.id,
+            speaker: {actor, alias: actor.name},
+            flavor,
+            rolls: result.rolls,
+            content: `${actor.name} has taken ${messagePart}`,
+            "flags.dnd5e.rest": {type: this.restOptions.restType}
+        };
+        ChatMessage.applyRollMode(chatData, game.settings.get("core", "rollMode"));
+        const chatMessage = await ChatMessage.create(chatData);
+        return {actor, result, chatMessage};
+    } 
+
+
+    /**
+     * An awful imitation of the dnd actor._rest function.
+     * @param {Actor5e} actor 
+     * @param {import("../system/dnd5e/dnd5e.mjs").RestConfiguration} config    Configuration data for the rest occurring.
+     * @returns {Promise<RestResult>}   Consolidated results of the rest workflow.
+     */
+    static async extendedRest(actor, config) {
+        let hitPointsRecovered = 0;
+        let result = {};
+        let hpActorUpdates = {};
+        let hitDiceRecovered = 0;
+        let hdActorUpdates = {};
+        let hdItemUpdates = [];
+        const rolls = [];
+        const newDay = true;
+
+        // Recover hit points & hit dice on long rest
+        const hpRecRes = actor._getRestHitPointRecovery();
+        ({ updates: hpActorUpdates, hitPointsRecovered } = hpRecRes);
+        const hdRecRes = actor._getRestHitDiceRecovery();
+        ({ updates: hdItemUpdates, actorUpdates: hdActorUpdates, hitDiceRecovered } = hdRecRes);
+
+        async function getItemUsesRecovery(actor, rolls) {
+            let recovery = ["sr", "lr", "day"]
+            let _updates = [];
+            for( let item of actor.items ) {
+                const uses = item.system.uses ?? {};
+
+                if ( recovery.includes(uses.per) ) {
+                    _updates.push({_id: item.id, "system.uses.value": uses.max});
+                }
+                if ( item.system.recharge?.value ) {
+                    _updates.push({_id: item.id, "system.recharge.charged": true});
+                }
+
+                if(uses.recovery && CONFIG.DND5E.limitedUsePeriods[uses.per]?.formula) {
+                    const roll = new Roll(uses.recovery, item.getRollData());
+                    roll.alter(14, 0, {multiplyNumeric: true});
+                    
+                    let total = 0;
+                    try {
+                        total = (await roll.evaluate()).total;
+                    } catch(err) {
+                        ui.notifications.warn(game.i18n.format("DND5E.ItemRecoveryFormulaWarning", {
+                            name: item.name,
+                            formula: uses.recovery
+                        }));
+                    }
+
+                    const newValue = Math.clamp(uses.value + total, 0, uses.max);
+                    if ( newValue !== uses.value ) {
+                        const diff = newValue - uses.value;
+                        const isMax = newValue === uses.max;
+                        const locKey = `DND5E.Item${diff < 0 ? "Loss" : "Recovery"}Roll${isMax ? "Max" : ""}`;
+                        _updates.push({_id: item.id, "system.uses.value": newValue});
+                        rolls.push(roll);
+                        await roll.toMessage({
+                            user: game.user.id,
+                            speaker: {actor, alias: actor.name},
+                            flavor: game.i18n.format(locKey, {name: item.name, count: Math.abs(diff)})
+                        });
+                    }
+                }
+            }
+            return _updates;
+        } 
+
+
+
+        // Figure out the rest of the changes
+        foundry.utils.mergeObject(result, {
+        dhd: (result.dhd ?? 0) + hitDiceRecovered,
+        dhp: (result.dhp ?? 0) + hitPointsRecovered,
+        updateData: {
+            ...(hdActorUpdates ?? {}),
+            ...hpActorUpdates,
+            ...actor._getRestResourceRecovery(),
+            ...actor._getRestSpellRecovery()
+        },
+        updateItems: [
+            ...(hdItemUpdates ?? []),
+            ...(await getItemUsesRecovery(actor, rolls))
+        ],
+        longRest: true,
+        newDay
+        });
+        result.rolls = rolls;
+
+        //perform updates
+        await actor.update(result.updateData, {isRest: true});
+        await actor.updateEmbeddedDocuments("Item", result.updateItems, { isRest: true });
+
+        // Advance the game clock
+        if ( config.advanceTime && (config.duration > 0) && game.user.isGM ) await game.time.advance(60 * config.duration);
+        return result;
+    } 
+}

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -74,6 +74,7 @@ function registerRulePages() {
     CONFIG.DND5E.rules.ancientarmor = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.teudeOPJnJzaJQiV";      //also in spellFailureChance.mjs
     CONFIG.DND5E.rules.undoingasurge = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.fXqW6yKBSh1Duwlw";
     CONFIG.DND5E.rules.spellscribing = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.RRUMkplfkv2jAr8s";
+    CONFIG.DND5E.rules.alternateskillchecks = "Compendium.talia-custom.rules.JournalEntry.ZkD6R9Ye9Sr77OCt.JournalEntryPage.5Nvw1Iiz3p8iJcED";
 
     //settlement rules
     CONFIG.DND5E.rules.settlementauthority = "Compendium.talia-custom.rules.JournalEntry.SJAQXPyELYfOfRE4.JournalEntryPage.CuGAAat2fnLmTJ2i";

--- a/world/_world.mjs
+++ b/world/_world.mjs
@@ -4,6 +4,7 @@ import spellFailureChance from "./spellFailureChance.mjs";
 import wildMagic from "./wildMagic/wildMagic.mjs";
 import customLimitedUsePeriods from "./customLimitedUsePeriods.mjs";
 import _settlement from "./settlement/_settlement.mjs";
+import damageAbsorption from "./damageAbsorption.mjs";
 
 
 export default {
@@ -14,5 +15,6 @@ export default {
         spellFailureChance.register();
         customLimitedUsePeriods.register();
         _settlement.registerSubsection();
+        damageAbsorption.register();
     }
 }

--- a/world/customLimitedUsePeriods.mjs
+++ b/world/customLimitedUsePeriods.mjs
@@ -49,7 +49,7 @@ function registerGMHook() {
         const isRoundChange = current.round !== prior.round;
 
         //filter alive, visible combatants and get their actors
-        const actors = combat.combatants.filter(c => c.defeated === false && c.hidden === false && typeof c.actor === "object").map(c => c.actor);
+        const actors = combat.combatants.filter(c => c.defeated === false && c.hidden === false && typeof c.actorId === "string").map(c => c.actor);
 
         for(let actor of actors) {
             //only check itemTypes which can have a system.uses property

--- a/world/damageAbsorption.mjs
+++ b/world/damageAbsorption.mjs
@@ -1,0 +1,22 @@
+export default {
+    register() {
+        Hooks.on("dnd5e.preCalculateDamage", fixDamageAbsorption);
+    }
+}
+
+/**
+ * Sets all damage types the actor would be taking to healing if the actor has the appropriate absorption and no bypass.
+ * @param {Actor} actor 
+ * @param {DamageDescription[]} damages 
+ * @param {DamageApplicationOptions} options 
+ */
+function fixDamageAbsorption(actor, damages, options) {
+    const da = actor.system?.traits?.da;
+    if(!da || !da.value?.size ) return;
+
+    for(let damage of damages) {
+        if(da.value.has(damage.type) && !da.bypasses.has(damage.type)) {
+            damage.type = "healing";
+        }
+    }
+}

--- a/world/settlement/settlement.mjs
+++ b/world/settlement/settlement.mjs
@@ -8,7 +8,7 @@ export default {
             await Building.init();
             TaliaCustomAPI.add({Settlement}, "none");
 
-            TaliaCustomAPI.add({SettlementJournalEntry}, "none");
+            //TaliaCustomAPI.add({SettlementJournalEntry}, "none");
         })();
     }
 }

--- a/wrappers/restrictMovement.mjs
+++ b/wrappers/restrictMovement.mjs
@@ -1,0 +1,64 @@
+import { MODULE } from "../scripts/constants.mjs";
+export default {
+    registerWrapper() {
+        libWrapper.register(MODULE.ID, "Token.prototype._canDrag", wrap_Token_prototype__canDrag, "WRAPPER");
+    }
+}
+
+//return result or false
+function wrap_Token_prototype__canDrag(wrapped, ...args) {
+    let result = wrapped(...args);
+    return allowMovement(this.document) ? result: false;
+}
+
+/**
+ * Determines if a token is allowed to move based on combat state and permissions.
+ * Movement is allowed in the following cases:
+ * - The user is a GM
+ * - No token is specified
+ * - No combat is active or combat hasn't started
+ * - The token is the current combatant
+ * - The current combatant is a vehicle owned by the user
+ * - The token is controlled by the current combatant and not in the combat turn order
+ * 
+ * If movement is blocked, displays a warning notification with a 2-second cooldown.
+ * 
+ * @param {Token} token - The token attempting to move
+ * @returns {boolean} True if movement is allowed, false otherwise
+ */
+function allowMovement(token) {
+    //always allow movement for GM or undefined token
+    if(game.user.isGM || token == undefined) return true;       
+
+    //always allow movement when there is no combat or it hasn't started yet
+    const curCombat = game.combats.active;
+    if(!curCombat || !curCombat.started) return true;       
+
+    // always allow movement of the current combatant
+    let entry = curCombat.combatant;
+    if(entry.tokenId == token.id) return true;
+
+    // always allow vehicle movement in combat
+    if(entry.actor?.type === "vehicle" && entry.actor?.isOwner) return true;
+
+    // Allow the Active Combatant to move all their controlled tokens in a Combat Turn
+    let curPermission = entry.actor?.ownership ?? {};
+    let tokPermission = token.actor?.ownership ?? {};
+    let ownedUsers = Object.keys(curPermission).filter(k => curPermission[k] === 3);    // Get all owners of the token
+    const anyDoubleOwner = ownedUsers.some(u => tokPermission[u] === 3 && !game.users?.get(u)?.isGM);    //Does any non-gm user who owns the current combatant also have ownership of the token?
+    const tokenNotInCombatTurnOrder = curCombat.turns.every(t => { return t.tokenId !== token.id; });    //Is the token NOT already in the combat turn order? (owned tokens, minions, etc should not be added to combat if they act on the owner's turn)
+    if(anyDoubleOwner && tokenNotInCombatTurnOrder) return true;
+      
+
+    // If all previous checks failed to return true, return false now and prevent token movement.
+
+    // Show a notification first through, with a timeout so it doesn't get spammed
+    if(!(token._movementNotified ?? false)) {
+        ui.notifications.warn("Movement blocked: It is currently not your turn.");
+        token._movementNotified = true;
+        setTimeout(function(token) {
+            delete token._movementNotified;
+        }, 5000, token);
+    }
+    return false;
+}


### PR DESCRIPTION
<details>
<summary><h2>Added</h2></summary>

- Plex Level 12
    - HD roll: 5
    - (ASI) +2 INT

-   <details>
    <summary>Items</summary>

    - Ioun Stone, Language Knowledge
    - Conch of Teleportation
    - Amulet of Proof against Detection and Location
    - Hoarfrost Shield
    - Bottle of Bagiennik Snot
    </details>

-   <details>
    <summary>Spells</summary>

    - Temporal Shunt
    - Gravity Fissure
    - Chain Lightning
    - Otiluke's Freezing Sphere
    - Curse of Biting Cold
    - Vortex Swap
    - Darkness
    </details>

-   <details>
    <summary>Rule: Alternate Skill Checks</summary>

    > Whenever you’re asked to make a skill check outside of combat, you may ask the DM if you can use a different skill by explaining how your character would approach the challenge. This can be expressed in whatever way you want - whether through description, narration, or in-character acting. The DM will consider your explanation and decide if the substitution is appropriate, and may adjust the difficulty (DC) of the check to reflect the nature of using the alternative skill.
    > 
    > Example Scenario: Imagine your ship has just sunk, and you're asked to make an Athletics (Strength) check to swim to the shore you can see in the distance. Depending on your character’s skills, you might approach this task differently. Here are a few examples for potential substitutions:
    > 
    > - Animal Handling (Wisdom): You recall seeing dolphins earlier and attempt to encourage them to guide you to shore.
    > - Nature (Intelligence): You’ve read about ocean currents and use this knowledge to align yourself with a helpful current.
    > - Survival (Wisdom): Having survived similar dangers, you focus on staying calm and moving efficiently.
    > - Performance (Charisma): You draw from water ballet skills you once learned to impress a merfolk, moving gracefully and efficiently through the waves.
    > 
    > Remember, creative substitutions are encouraged to enrich gameplay and give your character unique ways to face challenges, but they don’t guarantee success or a reduced difficulty.
    </details>

-   <details>
    <summary>Random Tables</summary>

    - Props - Settlements
    - Props - Nature
    </details>
- GmMacro `rest()` to choose a rest type and rest the actors of all selected tokens.
- Implemented damage absorption.
</details>

<details>
<summary><h2>Changed</h2></summary>

-   <details>
    <summary>Resting</summary>

    - Rests are now initiated by the GM.
    - Added rest type "extended rest" which lasts for 2 weeks.
    - Features which are used during the rest should now be used manually after the rest is completed. Of course they can just be roleplayed as being used during the rest itself, this is purely a mechanical change.
    </details>

-   <details>
    <summary>Chef Feat & Cooking</summary>

    - Remade the UI and workflow for Cooking
    - No longer initiates the rest.
    - Each serving now requires 1 food and (optionally) 1 spice.
    </details>
</details>

<details>
<summary><h2>Fixed</h2></summary>

- Items which roll to regain their expended uses now do so automatically again. This happens only after taking a rest and doesn't work for all rest types. (WIP)
- Error when a non-actor combatant was present during a combatTurnChange event.
</details>

<details>
<summary><h2>Removed Modules</h2></summary>

- Monk's Little Details
- Monk's Token Bar (Replaced the movement restriction in combat with custom code)
</details>