### PR TITLE
Added Legendary Vigor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,25 @@
 - Removed rerolling of initiative at the start of every round in combat as it makes working with active effects about as pleasant as french kissing a cheese grater.
 
 -   <details>
+    <summary>Legendary Vigor</summary>
+
+    from
+    > Before making a Strength or Constitution ability check or saving throw, you can expend 1 Mythic Power to automatically succeed, treating the result as a critical success without rolling.
+    
+    to
+    > By expending 1 Mythic Power as a free action on your turn, you can achieve feats of strength and endurance that most would consider to lie firmly in the realm of myth and legend. Alternatively, while it is not your turn, you can use this feature as a reaction, which you take before making a Strength or Constitution ability check or saving throw.
+    > 
+    > For 1 round per Mythic Rank, you gain the following benefits:
+    > - Whenever you make a Strength or Constitution ability check or saving throw, you treat a d20 roll of 19 or lower as a 20.
+    > - When using the Grapple action, you can grapple creatures of any size as if they were no more than one size larger than you.
+    > - The damage of your melee weapon attacks against structures and objects increases by a factor of 10 per Mythic Rank.
+    > - The maximum distance you can jump and the distance you can shove a creature when you use the Shove action both increase by a factor of 10 per mythic rank.
+    > - Your carrying capacity and the weight you can push, drag, or lift increases by a factor of 10 per Mythic Rank.
+    > 
+    > Immediately after this effect ends, the grappled condition ends on any creature grappled by you if its size exceeds the maximum size you can grapple.
+    </details>
+
+-   <details>
     <summary>Chef Feat</summary>
 
     - Various UI/UX improvements

--- a/features/mythic/legend.mjs
+++ b/features/mythic/legend.mjs
@@ -1,33 +1,85 @@
+import { MODULE } from "../../scripts/constants.mjs";
+
 export default {
     register() {
         unflinching();
+        legendaryVigor();
     }
 }
 
-
-/*
-  Legendary Vigor
-
-  - Whenever you make a Strength or Constitution ability check or saving throw, you treat a d20 roll of 19 or lower as a 20.
-        check dnd5e d20 roll class and see if there's something to hook into there
-        nope, gotta wrap CONFIG.Dice.D20Roll.prototype.configureModifiers to add support for custom terms
-
-
-  - When using the Grapple action, you can grapple creatures of any size as if they were no more than one size larger than you.
-  - The damage of your melee weapon attacks against structures and objects increases by a factor of 10 per Mythic Rank.
-  - The maximum distance you can jump and the distance you can shove a creature when you use the Shove action both increase by a factor of 10 per mythic rank.
-  - Your carrying capacity and the weight you can push, drag, or lift increases by a factor of 10 per Mythic Rank.
-  
-  Immediately after this effect ends, the grappled condition ends on any creature grappled by you if its size exceeds the maximum size you can grapple.
-*/
-
 /**
+ * Legendary Vigor
  *
+ * - Whenever you make a Strength or Constitution ability check or saving throw, you treat a d20 roll of 19 or lower as a 20.
+ * - When using the Grapple action, you can grapple creatures of any size as if they were no more than one size larger than you.
+ * - The damage of your melee weapon attacks against structures and objects increases by a factor of 10 per Mythic Rank.
+ * - The maximum distance you can jump and the distance you can shove a creature when you use the Shove action both increase by a factor of 10 per mythic rank.
+ * - Your carrying capacity and the weight you can push, drag, or lift increases by a factor of 10 per Mythic Rank.
+ * 
+ * Immediately after this effect ends, the grappled condition ends on any creature grappled by you if its size exceeds the maximum size you can grapple.
  */
 function legendaryVigor(requiredMythicRank = 1) {
-    /*
 
+    const VALID = {
+        abilityIds: ["str", "con"],
+        skillIds: Object.entries(CONFIG.DND5E.skills)
+            .filter(([_, v]) => v.ability === "str" || v.ability === "con")
+            .map(([k, _]) => k),
+    }
+
+    const getMythicRank = (actor) => {
+        return actor.getFlag(MODULE.ID, "mythicRank") ?? 0;
+    }
+
+    const passesFilter = (actor) => {
+        //make sure it only triggers for rolls made by actors with the legendary vigor AE active
+        return actor.appliedEffects.some(e => e.name === "Legendary Vigor" && e.active && !e.isSuppressed);
+    }
+
+    const modifyRoll = (rollData) => {  // mutates rollData
+        rollData.data.talia ??= {};
+        rollData.data.talia.legendaryVigor = true;
+    };
+
+    /*
+        - Whenever you make a Strength or Constitution ability check or saving throw, you treat a d20 roll of 19 or lower as a 20.
     */
+
+    Hooks.on("dnd5e.preRollSkill", (actor, rollData, skillId) => {
+        if(VALID.skillIds.includes(skillId) && passesFilter(actor)) modifyRoll(rollData);
+    });
+
+    Hooks.on("dnd5e.preRollAbilityTest", (actor, rollData, abilityId) => {
+        if(VALID.abilityIds.includes(abilityId) && passesFilter(actor)) modifyRoll(rollData);
+    });
+
+    Hooks.on("dnd5e.preRollAbilitySave", (actor, rollData, abilityId) => {
+        if(VALID.abilityIds.includes(abilityId) && passesFilter(actor)) modifyRoll(rollData);
+    });
+
+    Hooks.on("talia_postConfigureD20Modifiers", (d20Roll) => {
+        //make sure it only triggers for rolls made by actors with the legendary vigor AE active
+        if(!d20Roll.data?.talia?.legendaryVigor) return;
+        const d20 = d20Roll.terms[0];
+        d20.modifiers.push("min20");
+    });
+
+    /*
+        - The maximum distance you can jump and the distance you can shove a creature when you use the Shove action both increase by a factor of 10 per mythic rank.
+    */
+    Hooks.on("talia_postCalculateJumpDistance", (actor, distanceObj) => {
+        if(passesFilter(actor)) {
+            const mr = getMythicRank(actor);
+            if(mr) distanceObj.newValue = distanceObj.rounded * 10 * mr;
+        }
+    });
+    // note: Not yet implemented.
+    Hooks.on("talia_postCalculateShoveDistance", (actor, distanceObj) => {
+        if(passesFilter(actor)) {
+            const mr = getMythicRank(actor);
+            if(mr) distanceObj.newValue = distanceObj.rounded * 10 * mr;
+        }
+    });
 }
 
 /**

--- a/features/shared/commonActions/WIP_shove.mjs
+++ b/features/shared/commonActions/WIP_shove.mjs
@@ -36,6 +36,11 @@
     }
 */
 
+/*
+    uses Hooks.callAll("talia_postCalculateShoveDistance", actor, distanceObj) to allow other scripts to mutate distanceObj.newValue after calculation.
+    See jump.mjs for details.
+*/
+
 export default {
     _onDAESetup() {
         const fields = [];

--- a/features/shared/commonActions/grapple.mjs
+++ b/features/shared/commonActions/grapple.mjs
@@ -5,15 +5,24 @@
 */
 
 import { TaliaCustomAPI } from "../../../scripts/api.mjs";
+import { MODULE } from "../../../scripts/constants.mjs";
 
 export default {
     register() {
         TaliaCustomAPI.add({grapple: grappleItemMacro}, "ItemMacros");
+        Hooks.once("setup", () => {
+            const fields = [];
+            fields.push("flags.talia-custom.ignoreGrappleSizeLimit");
+            DAE.addAutoFields(fields);
+        });
     }
 }
 
 /**
- *
+ * 
+ * @param {Item} item 
+ * @param {Token} actorToken 
+ * @returns {void}
  */
 async function grappleItemMacro(item, actorToken) {
     if(actorToken.actor.effects.find(e => e.name === "Grappling")) {
@@ -49,7 +58,7 @@ async function grappleItemMacro(item, actorToken) {
     }
     const actorGrappleSizeIndex = grappleSizeIndex(actorRD);
     const targetGrappleSizeIndex = grappleSizeIndex(targetRD);
-    if(targetGrappleSizeIndex > actorGrappleSizeIndex + 1) {
+    if((targetGrappleSizeIndex > actorGrappleSizeIndex + 1) && actorRD.getFlag(MODULE.ID, "ignoreGrappleSizeLimit") !== 1) {
         ui.notifications.warn("This creature is too big for you to grapple.");
         return null;
     }

--- a/features/shared/commonActions/jump.mjs
+++ b/features/shared/commonActions/jump.mjs
@@ -42,8 +42,17 @@ class Jump {
         const distMult = Math.clamp(Math.pow(2, distDouble - distHalf), 0.25, 4);
 
         const calculatedDistance = (baseDistance + distAdd) * distMult;
+
         //round that to the nearest interval of 5
-        return Math.round(calculatedDistance / 5) * 5;
+        let roundedDistance = Math.round(calculatedDistance / 5) * 5;
+
+        //lets other scripts modify the final calculated and rounded distance
+        const distanceObj = {
+            rounded: roundedDistance,
+            newValue: null
+        };
+        Hooks.callAll("talia_postCalculateJumpDistance", actor, distanceObj );
+        return distanceObj.newValue ?? distanceObj.rounded;
     }
 
     static async itemMacro(item) {

--- a/wrappers/_wrappers.mjs
+++ b/wrappers/_wrappers.mjs
@@ -7,6 +7,7 @@ export function registerWrappers() {
     libWrapper.register(MODULE.ID, 'dnd5e.applications.actor.ActorSheet5e.prototype.maximize', wrap_ActorSheet_maximize, "MIXED");
     libWrapper.register(MODULE.ID, 'dnd5e.canvas.AbilityTemplate.prototype._finishPlacement', wrap_AbilityTemplate_finishPlacement, "WRAPPER");
     libWrapper.register(MODULE.ID, "dnd5e.applications.components.DamageApplicationElement.prototype.getTargetOptions", wrap_DamageApplicationElement_getTargetOptions, "WRAPPER");
+    libWrapper.register(MODULE.ID, "CONFIG.Dice.D20Roll.prototype.configureModifiers", wrap_CONFIG_Dice_D20Roll_prototype_configureModifiers, "WRAPPER");
     restrictMovement.registerWrapper();
 }
 
@@ -42,4 +43,13 @@ function wrap_DamageApplicationElement_getTargetOptions(wrapped, ...args) {
     const ret = wrapped(...args);
     ret.originatingMessageId = this.chatMessage?.id;
     return ret;
+}
+
+/** Adds a hook to configure the dice modifiers of a D20Roll. The hook can mutate the roll! */
+function wrap_CONFIG_Dice_D20Roll_prototype_configureModifiers(wrapped, ...args) {
+    wrapped(...args);
+    Hooks.callAll("talia_postConfigureD20Modifiers", this);
+
+    // Re-compile the underlying formula
+    this._formula = this.constructor.getFormula(this.terms);
 }


### PR DESCRIPTION
closes #181

- Add flag for ignoring grapple size limit
- `talia-custom.ignoreGrappleSizeLimit` allows an actor to grapple actors of any size
- Added hook "talia_postConfigureD20Modifier" to allow configuration of d20 rolls that would otherwise be impossible.
- cleanup grappling changes
- add grapple AE flag to DAE autoFields
- Added hook "talia_postCalculateJumpDistance" to allow the rounded distance to be modified by other scripts.
- fixed jump hook so newValue can actually be mutated
- added notes to shove regarding a "talia_postCalculateShoveDistance" Hook
