### PR TITLE
Dev 1.11.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,62 @@
 # 1.11.0 - 2024/11/26
 
 <details>
+<summary><h2>Added</h2></summary>
+
+- Spells
+    - Anticipate Arcana
+    - Command
+    -   <details>
+        <summary>Ray of Sickness</summary>
+
+        from
+        > A ray of sickening greenish energy lashes out toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 2d8 poison damage and must make a Constitution saving throw. On a failed save, it is also poisoned until the end of your next turn.
+        > 
+        > At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.
+
+        to
+        > A ray of sickening greenish energy lashes out toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 2d8 poison damage and becomes poisoned until the end of your next turn.
+        > 
+        > At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.
+        </details>
+    -   <details>
+        <summary>Chill Touch</summary>
+
+        from
+        > You create a ghostly, skeletal hand in the space of a creature within range. Make a ranged spell attack against the creature to assail it with the chill of the grave. On a hit, the target takes 1d8 necrotic damage, and it can't regain hit points until the start of your next turn. Until then, the hand clings to the target.
+        > 
+        > If you hit an undead target, it also has disadvantage on attack rolls against you until the end of your next turn.
+        > 
+        > This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).
+
+        to
+        > You create a ghostly, skeletal hand in the space of a creature within range. Make a ranged spell attack against the creature to assail it with the chill of the grave. On a hit, the target takes 1d8 necrotic damage, and it can't regain hit points until the start of your next turn. Until then, the hand clings to the target.
+        > 
+        > If you hit an undead target, it also has disadvantage on attack rolls against you until the start of your next turn.
+        > 
+        > This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).
+        </details>
+    - Stinking Cloud
+</details>
+
+<details>
 <summary><h2>Changed</h2></summary>
 
 - Removed rerolling of initiative at the start of every round in combat as it makes working with active effects about as pleasant as french kissing a cheese grater.
 
+-   <details>
+    <summary>Cure Wounds</summary>
+
+    from
+    > A creature you touch regains a number of hit points equal to 1d8 + your spellcasting ability modifier. This spell has no effect on undead or constructs.
+    >
+    > At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the healing increases by 1d8 for each slot level above 1st.
+
+    to
+    > A creature you touch regains a number of hit points equal to 2d8 + your spellcasting ability modifier. This spell has no effect on undead or constructs.
+    > 
+    > At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the healing increases by 2d8 for each slot level above 1st.
+    </details>
 -   <details>
     <summary>Legendary Vigor</summary>
 

--- a/changelog.md
+++ b/changelog.md
@@ -37,13 +37,24 @@
         > This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).
         </details>
     - Stinking Cloud
+    - Microscopic Proportions
 </details>
 
 <details>
 <summary><h2>Changed</h2></summary>
 
 - Removed rerolling of initiative at the start of every round in combat as it makes working with active effects about as pleasant as french kissing a cheese grater.
+-   <details>
+    <summary>Master of Chance</summary>
 
+    from 
+    > You have a bonus to skill checks with one skill equal to 5 times your Charisma modifier.
+    > This bonus changes to a different skill whenever you make a skill check, though it can apply to the same skill multiple times in a row.
+    > You are not aware of which skill this bonus currently affects.
+
+    to
+    > When you make any skill check, roll an additional d12. If it lands on a 12, you gain a bonus to that skill check equal to 5 times your Charisma modifier.
+    </details>
 -   <details>
     <summary>Cure Wounds</summary>
 

--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -4,4 +4,3 @@
 - In case of merge conflicts, **retain all entries** to ensure no changes are lost.
 - During release preparation, entries from this file are reviewed, organized, and moved into the main `changelog.md`.
 # Drafts
-change: Master of Chance now triggers for 8.33% of skill checks.

--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -1,0 +1,6 @@
+# Structure
+- Each feature branch appends its entries to this file under the appropriate category.
+- Prefix each entry with one of the following tags: `add:`, `change:`, `remove:`, or `fix:` to specify the type of change.
+- In case of merge conflicts, **retain all entries** to ensure no changes are lost.
+- During release preparation, entries from this file are reviewed, organized, and moved into the main `changelog.md`.
+# Drafts

--- a/features/mythic/_mythic.mjs
+++ b/features/mythic/_mythic.mjs
@@ -1,4 +1,7 @@
 import legend from "./legend.mjs"
+import lich from "./lich.mjs"
+import trickster from "./trickster.mjs"
+import dragon from "./dragon.mjs"
 
 export default {
     registerSubsection() {
@@ -7,5 +10,8 @@ export default {
         }
 
         legend.register();
+        lich.register();
+        trickster.register();
+        dragon.register();
     }
 }

--- a/features/mythic/dragon.mjs
+++ b/features/mythic/dragon.mjs
@@ -1,0 +1,5 @@
+export default {
+    register() {
+
+    }
+}

--- a/features/mythic/lich.mjs
+++ b/features/mythic/lich.mjs
@@ -1,0 +1,5 @@
+export default {
+    register() {
+
+    }
+}

--- a/features/mythic/trickster.mjs
+++ b/features/mythic/trickster.mjs
@@ -1,0 +1,5 @@
+export default {
+    register() {
+
+    }
+}


### PR DESCRIPTION
<details>
<summary><h2>Added</h2></summary>

- Spells
    - Anticipate Arcana
    - Command
    -   <details>
        <summary>Ray of Sickness</summary>

        from
        > A ray of sickening greenish energy lashes out toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 2d8 poison damage and must make a Constitution saving throw. On a failed save, it is also poisoned until the end of your next turn.
        > 
        > At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.

        to
        > A ray of sickening greenish energy lashes out toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 2d8 poison damage and becomes poisoned until the end of your next turn.
        > 
        > At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.
        </details>
    -   <details>
        <summary>Chill Touch</summary>

        from
        > You create a ghostly, skeletal hand in the space of a creature within range. Make a ranged spell attack against the creature to assail it with the chill of the grave. On a hit, the target takes 1d8 necrotic damage, and it can't regain hit points until the start of your next turn. Until then, the hand clings to the target.
        > 
        > If you hit an undead target, it also has disadvantage on attack rolls against you until the end of your next turn.
        > 
        > This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).

        to
        > You create a ghostly, skeletal hand in the space of a creature within range. Make a ranged spell attack against the creature to assail it with the chill of the grave. On a hit, the target takes 1d8 necrotic damage, and it can't regain hit points until the start of your next turn. Until then, the hand clings to the target.
        > 
        > If you hit an undead target, it also has disadvantage on attack rolls against you until the start of your next turn.
        > 
        > This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).
        </details>
    - Stinking Cloud
    - Microscopic Proportions
</details>

<details>
<summary><h2>Changed</h2></summary>

- Removed rerolling of initiative at the start of every round in combat as it makes working with active effects about as pleasant as french kissing a cheese grater.
-   <details>
    <summary>Master of Chance</summary>

    from 
    > You have a bonus to skill checks with one skill equal to 5 times your Charisma modifier.
    > This bonus changes to a different skill whenever you make a skill check, though it can apply to the same skill multiple times in a row.
    > You are not aware of which skill this bonus currently affects.

    to
    > When you make any skill check, roll an additional d12. If it lands on a 12, you gain a bonus to that skill check equal to 5 times your Charisma modifier.
    </details>
-   <details>
    <summary>Cure Wounds</summary>

    from
    > A creature you touch regains a number of hit points equal to 1d8 + your spellcasting ability modifier. This spell has no effect on undead or constructs.
    >
    > At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the healing increases by 1d8 for each slot level above 1st.

    to
    > A creature you touch regains a number of hit points equal to 2d8 + your spellcasting ability modifier. This spell has no effect on undead or constructs.
    > 
    > At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the healing increases by 2d8 for each slot level above 1st.
    </details>
-   <details>
    <summary>Legendary Vigor</summary>

    from
    > Before making a Strength or Constitution ability check or saving throw, you can expend 1 Mythic Power to automatically succeed, treating the result as a critical success without rolling.
    
    to
    > By expending 1 Mythic Power as a free action on your turn, you can achieve feats of strength and endurance that most would consider to lie firmly in the realm of myth and legend. Alternatively, while it is not your turn, you can use this feature as a reaction, which you take before making a Strength or Constitution ability check or saving throw.
    > 
    > For 1 round per Mythic Rank, you gain the following benefits:
    > - Whenever you make a Strength or Constitution ability check or saving throw, you treat a d20 roll of 19 or lower as a 20.
    > - When using the Grapple action, you can grapple creatures of any size as if they were no more than one size larger than you.
    > - The damage of your melee weapon attacks against structures and objects increases by a factor of 10 per Mythic Rank.
    > - The maximum distance you can jump and the distance you can shove a creature when you use the Shove action both increase by a factor of 10 per mythic rank.
    > - Your carrying capacity and the weight you can push, drag, or lift increases by a factor of 10 per Mythic Rank.
    > 
    > Immediately after this effect ends, the grappled condition ends on any creature grappled by you if its size exceeds the maximum size you can grapple.
    </details>

-   <details>
    <summary>Chef Feat</summary>

    - Various UI/UX improvements
    - Mechanical changes:
    
    from
    > Time spent mastering the culinary arts has paid off, granting you the following benefits:
    > - Increase your Dexterity, Constitution, or Wisdom by 1, to a maximum of 20.
    > - You gain proficiency with cook's utensils if you don't already have it.
    > - As part of a short rest, you can cook a quick snack for your party, provided you have ingredients and cook's utensils on hand. Doing so takes one snack item for each party member and lets everyone in your party regain hit points equal to 1d8 * your proficiency bonus.
    > - When you finish a long rest and at the cost of one meal item per party member, you can make a meal for your party that gives them temporary hit points equal to 2d4 * your proficiency bonus.

    to
    > Time spent mastering the culinary arts has paid off, increasing your Dexterity score by 1, to a maximum of 20, and granting you proficiency with cook's utensils if you didn't already have it.
    > 
    > If you have ingredients and cook's utensils on hand, you can prepare up to 10 meals during one hour of dedicated work or as part of a short or long rest. Each meal requires one food and, optionally, one spice.
    > 
    > When preparing a meal, you can choose to enhance either its restorative or preventative properties, granting it one of the following benefits:
    > - Restorative. The creature regains a number of hit points equal to 1d8 * your proficiency bonus.
    > - Preventative. The creature gains a number of temporary hit points equal to 2d4 * your proficiency bonus.
    > 
    > Meals retain these enhanced properties only while fresh, meaning they must be consumed within 30 minutes of preparation. A creature that consumes a fresh meal gains the selected benefit as well as the effect of any spice used to flavor the meal.
    > 
    > A creature can benefit from only one enhanced meal per rest period.
    </details>
</details>

<details>
<summary><h2>Removed</h2></summary>

- Removed subtype "snack" from lootTypes.food
</details>