### PR TITLE
Add critical success/failure display for d20 rolls of types other than attack rolls and death saves

### DIFF
--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -20,3 +20,4 @@ add: Armor of the Litr Rune
 add: A Series Of Unfortunate Events
 add: Rule: Reduced Statistics
 add: Mythic Trickster 2 - Active
+add: Chat messages now display critical successes and fumbles for skill checks, tool checks, ability checks, and saving throws, in addition to the default attack rolls and death saves.


### PR DESCRIPTION
Closes #196

Added an OVERRIDE wrapper for `dnd5e.documents.ChatMessage5e.prototype._highlightCriticalSuccessFailure` which retains all original functionality but allows skill checks, tool checks, ability checks, and saving throws to be displayed as critical successes or fumbles in addition to the default attack rolls and death saves.