### PR TITLE
Mythic 2 - Lich Active

### DIFF
--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -16,3 +16,4 @@ todo: add graphics for the hoard
 - added: Actor5e.prototype.getWealth() method
 - added: spell: Withering Touch
 - added: Mythic Lich 2 passive feature
+- added: Mythic Lich 2 active feature

--- a/features/mythic/lich.mjs
+++ b/features/mythic/lich.mjs
@@ -3,6 +3,7 @@ import ChatCardButtons from "../../utils/chatCardButtons.mjs"
 export default {
     register() {
         essence_tithe();
+        rite_of_profane_power();
     }
 }
 
@@ -68,4 +69,87 @@ function essence_tithe() {
             }
         ]
     })
+}
+
+/**
+ * Registers the ChatCardButton for Rite of Profane Power.
+ * Lets the user choose a school of magic and then adds the active effect for that school.
+ */
+function rite_of_profane_power() {
+    const ABILITY_CONFIG = {
+        effectDurationInSeconds: 60 * 60 * 24,      //24h
+    }
+
+    ChatCardButtons.register({
+        itemName: "Rite of Profane Power",
+        buttons: [
+            {
+                label: "Choose School of Magic",
+                callback: async ({actor, item}) => {
+                    const schoolsCfg = CONFIG.DND5E.spellSchools;
+
+                    //check rituals present
+                    const mythicRank = actor.flags["talia-custom"]?.mythicRank ?? 0;
+                    const maxRituals = Math.ceil(mythicRank / 2);
+                    const presentRitualEffects = actor.appliedEffects.filter(e => e.origin === item.uuid) ?? [];
+                    if(presentRitualEffects.length >= maxRituals && !game.user.isGM) {
+                        ui.notifications.warn(`You can only benefit from up to ${maxRituals} ritual at mythic rank ${mythicRank}.`);
+                        return;
+                    }
+
+                    //choose spell school
+                    const chosenSchoolId = await (async() => {
+                        const {DialogV2} = foundry.applications.api;
+                        const {StringField} = foundry.data.fields;
+
+                        const selectSpellSchoolGroup = new StringField({
+                            label: "Select a School",
+                            required: true,
+                            choices: Object.entries(schoolsCfg).reduce((acc, [k, v]) => {
+                                acc[k] = v.label;
+                                return acc;
+                            }, {}),
+                        }).toFormGroup({}, {name: "schoolId"}).outerHTML;
+
+                        const choice = await DialogV2.prompt({
+                            window: { title: item.name },
+                            content: selectSpellSchoolGroup,
+                            rejectClose: false,
+                            ok: {
+                                callback: (event, button) => new FormDataExtended(button.form).object,
+                            }
+                        });
+                        return choice?.schoolId ?? null;
+                    })();
+                    if(!chosenSchoolId) return;
+
+                    //create effect data
+                    const effectData = {
+                        name: `Profane ${schoolsCfg[chosenSchoolId].label}`,
+                        origin: item.uuid,
+                        description: `<p>Whenever you cast a ${schoolsCfg[chosenSchoolId].label} spell by expending a spell slot, the spell is treated as if it were cast using a spell slot ${chosenSchoolId === "nec" ? "two levels" : "one level"} higher, up to a maximum of 9th level.</p>`,
+                        flags: {
+                            dae: { stackable: "noneName"}
+                        },
+                        duration: {
+                            seconds: ABILITY_CONFIG.effectDurationInSeconds
+                        },
+                        img: item.img,
+                        transfer: false,
+                        changes: [
+                            {
+                                key: `flags.talia-custom.modifySpellLevel.spellSchools.${chosenSchoolId}`,
+                                mode: 2,
+                                priority: 20,
+                                value: chosenSchoolId === "nec" ? 2 : 1
+                            }
+                        ]
+                    };
+
+                    //apply effect
+                    await game.dfreds.effectInterface.addEffect({ effectData, uuid: actor.uuid });
+                }
+            }
+        ]
+    });
 }

--- a/utils/utilHooks.mjs
+++ b/utils/utilHooks.mjs
@@ -2,6 +2,7 @@ export default {
     register() {
         registerEquipAttuneHook();
         registerHideChatMessageHook();
+        registerModifySpellLevelHook(); 
     }
 }
 
@@ -32,5 +33,64 @@ function registerHideChatMessageHook() {
         if(msg.flags?.["talia-custom"]?.hideFromSelf === true && !game.user.isGM && msg.author?.id === game.userId) {
             html.style.display = "none";
         }
+    });
+}
+
+/**
+ * Rule: "When cast a spell using a spell slot, the spell is treated as if it were cast using a spell slot of x levels higher/lower, up to a maximum of 9th level."
+ * 
+ * Checks if the actor casting the spell has one of the following flags (can be expanded later):
+ * - talia-custom.modifySpellLevel.spellSchools[spellSchoolId] {number}
+ */
+function registerModifySpellLevelHook() {
+    Hooks.on("dnd5e.preItemUsageConsumption", (item, config, options) => {
+        //prevent recursion
+        if(options.talia?.modifiedSpellLevel) return;
+        //prevent invalid items
+        if(!item.type === "spell" || !config.slotLevel || config.slotLevel === 0) return;
+
+        const modFlag = item.actor?.flags?.["talia-custom"]?.modifySpellLevel;
+        if(!modFlag) return;
+
+        const chosenSlotLevel = options.flags.dnd5e?.use?.spellLevel;
+        if(!chosenSlotLevel) return;
+
+        let slotLevelModifier = 0;
+        //add all flag values together
+        slotLevelModifier += modFlag.spellSchools?.[item.system.school] ?? 0;
+
+        //calculate changed slot level; min = 1, max = 9;
+        const newSlotLevel = Math.min(1, Math.max(chosenSlotLevel + slotLevelModifier, 9));
+        if(newSlotLevel === chosenSlotLevel) return;
+
+        //start async function, then return false to cancel the use
+        (async() => {
+            //consume spell slot manually if set in the original config
+            if( config.consumeSpellSlot ) {
+                const spellData = item.actor?.system.spells ?? {};
+                const level = spellData[config.slotLevel];
+                const spells = Number(level?.value ?? 0);
+
+                if ( spells === 0 ) {
+                    const isLeveled = /spell\d+/.test(config.slotLevel || "");
+                    const labelKey = isLeveled ? `DND5E.SpellLevel${item.system.level}`: `DND5E.SpellProg${config.slotLevel?.capitalize()}`;
+                    const label = game.i18n.localize(labelKey);
+                    ui.notifications.warn(game.i18n.format("DND5E.SpellCastNoSlots", {name: item.name, level: label}));
+                    return false;
+                }
+                await item.actor.update({[`system.spells.${config.slotLevel}.value`]: Math.max(spells - 1, 0)});
+            }
+
+            // then use the item again but don't consume spell slots and specify the slot level used (and all other config choices)
+            config.consumeSpellSlot = false;
+            config.slotLevel = newSlotLevel;
+
+            options.configureDialog = false;
+            options.talia ??= {};
+            options.talia.modifiedSpellLevel = true;
+
+            await item.use(config, options);
+        })();
+        return false;
     });
 }

--- a/world/_world.mjs
+++ b/world/_world.mjs
@@ -6,6 +6,7 @@ import customLimitedUsePeriods from "./customLimitedUsePeriods.mjs";
 import _settlement from "./settlement/_settlement.mjs";
 import damageAbsorption from "./damageAbsorption.mjs";
 import _guildmanager from "./guildmanager/_guildmanager.mjs";
+import addActiveEffectFields from "./addActiveEffectFields.mjs";
 
 
 export default {
@@ -17,5 +18,6 @@ export default {
         customLimitedUsePeriods.register();
         _settlement.registerSubsection();
         damageAbsorption.register();
+        addActiveEffectFields.register();
     }
 }

--- a/world/addActiveEffectFields.mjs
+++ b/world/addActiveEffectFields.mjs
@@ -1,0 +1,21 @@
+export default {
+    register() {
+        Hooks.once("setup", () => {
+            const fields = [];
+            getDaeAutoFields(fields);
+            DAE.addAutoFields(fields);
+        });
+    }
+}
+
+/**
+ * 
+ * @param {[]} fields   Gets mutated;
+ */
+function getDaeAutoFields(fields) {
+    // add modifySpellLevel.spellSchools._ fields
+    fields.push(
+        ...Object.keys(CONFIG.DND5E.spellSchools)
+            .map(k => `flags.talia-custom.modifySpellLevel.spellSchools.${k}`)
+    );
+}


### PR DESCRIPTION
Closes #163

- Adds an active effect key `talia-custom.modifySpellLevel.spellSchools[spellSchoolId] || ADD || {number}` which adds  `{number}` to the level of a spell of the chosen school if the spell was cast using a spell slot (spell slot selection available).