### PR TITLE
Fix item descriptions and improve Stone's Endurance UX

### DIFF
--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -25,3 +25,8 @@
     - Drow Poison
     - Torpor  
     ...as well as any potions, spell scrolls, or spell gems based on these
+- fix: Various faulty item descriptions in compendium
+    - Sapping Sting
+    - Thunder Step
+    - Jim's Magic Missile
+- change: Stone's Endurance: Added auto roll on use and removed "healing" tag (no mechanical changes).

--- a/features/character/aviana/_aviana.mjs
+++ b/features/character/aviana/_aviana.mjs
@@ -1,11 +1,13 @@
 import beastSpirits from "./beastSpirits.mjs"
 import divingStrike from "./divingStrike.mjs";
 import relentlessRage from "./relentlessRage.mjs";
+import stonesEndurance from "./stonesEndurance.mjs";
 
 export default {
     registerSubsection() {
         beastSpirits.register();
         relentlessRage.register();
         divingStrike.register();
+        stonesEndurance.register();
     }
 }

--- a/features/character/aviana/stonesEndurance.mjs
+++ b/features/character/aviana/stonesEndurance.mjs
@@ -1,0 +1,14 @@
+export default {
+    register() {
+        Hooks.on("dnd5e.useItem", async (item, config, options) => {
+            if(item.name !== "Stone's Endurance") return;
+
+            const rollData = item.actor.getRollData();
+            const roll = await new Roll("1d12 + @abilities.con.mod", rollData).evaluate();
+            await roll.toMessage({
+                flavor: "Damage Reduction",
+                speaker: ChatMessage.implementation.getSpeaker({actor: item.actor}),
+            });
+        })
+    }
+}


### PR DESCRIPTION
- fix: Various faulty item descriptions in compendium
    - Sapping Sting
    - Thunder Step
    - Jim's Magic Missile

- change: Stone's Endurance: Added auto roll on use and removed "healing" tag (no mechanical changes).