### PR TITLE
Fix 'dead' status effect and 'Mark NPC Defeated' macro errors

### DIFF
--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -5,3 +5,4 @@
 - During release preparation, entries from this file are reviewed, organized, and moved into the main `changelog.md`.
 # Drafts
 - fix: set 2nd argument of `wrap_Actor_prototype_toggleStatusEffect` as optional
+- fix: Errors with 'dead' status effect and 'Mark NPC Defeated' macro [#263](https://github.com/Belodri/talia-custom/issues/263)

--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -5,4 +5,4 @@
 - During release preparation, entries from this file are reviewed, organized, and moved into the main `changelog.md`.
 # Drafts
 - fix: set 2nd argument of `wrap_Actor_prototype_toggleStatusEffect` as optional
-- fix: Errors with 'dead' status effect and 'Mark NPC Defeated' macro [#263](https://github.com/Belodri/talia-custom/issues/263)
+- fix: Errors with 'dead' status effect and 'Mark NPC Defeated' macro


### PR DESCRIPTION
- fix: Errors with 'dead' status effect and 'Mark NPC Defeated' macro

Fixes #263