### PR TITLE
Spells cast from spell gems should count as spells for BaB

### DIFF
--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -4,3 +4,26 @@
 - In case of merge conflicts, **retain all entries** to ensure no changes are lost.
 - During release preparation, entries from this file are reviewed, organized, and moved into the main `changelog.md`.
 # Drafts
+- Spell gems are now considered to be spells instead of consumables for bab.
+    - modified SpellGem creation to record spellSchool and component (only somatic, set for all spell gems) in flag on spell gem
+    - modified the following methods in bab's code:
+        - `RollHooks.preDisplayCard`
+        - `FilterManager.itemTypes`
+        - `FilterManager.spellSchools`
+        - `FilterManager.spellComponents`
+        - `FilterManager.spellLevels`
+    - updated items to use bab instead of ActiveEffects to modify spell attacks and spell save DCs
+        - Circlet of Blasting +1
+        - Infernal Amulet
+        - Sun Statue
+        - Bless
+        - Potion of Heroism
+        - High Priest's Obsidian Battleaxe
+    - updated items to work with these changes
+        - Rod of Hellish Flames
+    
+    In summary this means that spellgems should now benefit from the same conditional bonuses that apply to actual spells.
+
+    > **Note:**  
+    > Spell gems created before this patch do not work with bonuses that apply only to spells of a certain school.   
+    > At the time of writing, Evocation Wizard's feature Empowered Evocation is the only thing affected by this.

--- a/features/professions/spellscribing/SpellGem.mjs
+++ b/features/professions/spellscribing/SpellGem.mjs
@@ -20,7 +20,7 @@ export async function createSpellGem(actor, chosenArgs) {
     //fixes after creating the scroll but before creating the actual spell gem on the actor
     foundry.utils.mergeObject(workingObj, {
         "system.description.value": `${chosenArgs.isTrigger ? `<p><strong>Trigger: </strong>${chosenArgs.triggerConditions}</p><hr>` : ""}${workingObj.system.description.value}`,
-        "system.properties": ["mgc"],
+        "system.properties": ["mgc", "somatic"],
     });
     
     const [newItem] = await actor.createEmbeddedDocuments("Item", [workingObj]);
@@ -51,6 +51,7 @@ function getChanges(actor, chosenArgs) {
         "system.rarity": chosenArgs.chosenGem.system.rarity,
         "system.price.value": chosenArgs.chosenGem.system.price.value,
         "system.weight.value": chosenArgs.chosenGem.system.weight.value,
+        "flags.talia-custom.spellGem.school": chosenArgs.chosenSpell.system.school,
     };
 
     //attack changes


### PR DESCRIPTION
- Spell gems are now considered to be spells instead of consumables for bab.
    - modified SpellGem creation to record spellSchool and component (only somatic, set for all spell gems) in flag on spell gem
    - modified the following methods in bab's code:
        - `RollHooks.preDisplayCard`
        - `FilterManager.itemTypes`
        - `FilterManager.spellSchools`
        - `FilterManager.spellComponents`
        - `FilterManager.spellLevels`
    - updated items to use bab instead of ActiveEffects to modify spell attacks and spell save DCs
        - Circlet of Blasting +1
        - Infernal Amulet
        - Sun Statue
        - Bless
        - Potion of Heroism
        - High Priest's Obsidian Battleaxe
    - updated items to work with these changes
        - Rod of Hellish Flames
    
    In summary this means that spellgems should now benefit from the same conditional bonuses that apply to actual spells.

    > **Note:**  
    > Spell gems created before this patch do not work with bonuses that apply only to spells of a certain school.   
    > At the time of writing, Evocation Wizard's feature Empowered Evocation is the only thing affected by this.

Closes #261