### PR TITLE
Repeating item use bugs

### DIFF
--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -27,3 +27,4 @@
     > **Note:**  
     > Spell gems created before this patch do not work with bonuses that apply only to spells of a certain school.   
     > At the time of writing, Evocation Wizard's feature Empowered Evocation is the only thing affected by this.
+- fixed: Active Effects with automated repeating item use trigger 'onTurnEnd' not triggering

--- a/utils/RepeatingEffects.mjs
+++ b/utils/RepeatingEffects.mjs
@@ -94,7 +94,7 @@ class CombatTriggers {
         if (turnForward) {
             // Retrieve combatants.
             const previousId = foundry.utils.getProperty(options, `${MODULE.ID}.previousCombatant`);
-            const previousCombatant = !combatStarted ? combat.combatants.get(previousId) : null;
+            const previousCombatant = combatStarted ? combat.combatants.get(previousId) : null;
 
             // Execute turn start and turn end triggers.
             CombatTriggers._executeAppliedEffects(combat.combatant?.actor, "onTurnStart");
@@ -311,6 +311,7 @@ async function getSourceItem(effect) {
 /**
  * @param {import ("../system/dnd5e/module/documents/actor/actor.mjs").default} actor 
  * @param {import ("../system/dnd5e/module/documents/active-effect.mjs").default} effect 
+ * @param {string} hook 
  */
 async function createItemMessage(actor, effect, hook) {
     let sourceItem = await getSourceItem(effect);


### PR DESCRIPTION
- fixed: Active Effects with automated repeating item use trigger 'onTurnEnd' not triggering

Effects from destroyed consumables weren't the issue as they work just fine.

Fixes #260