### PR TITLE
Status effects caused by active effects are not correctly removed in certain cases

### DIFF
--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -28,3 +28,4 @@
     > Spell gems created before this patch do not work with bonuses that apply only to spells of a certain school.   
     > At the time of writing, Evocation Wizard's feature Empowered Evocation is the only thing affected by this.
 - fixed: Active Effects with automated repeating item use trigger 'onTurnEnd' not triggering
+- fixed: Status effects should now be toggled off correctly, even in cases where the Active Effect created by the status effect also had statuses other than itself.


### PR DESCRIPTION
- fixed: Status effects should now be toggled off correctly, even in cases where the Active Effect created by the status effect also had statuses other than itself.

see changes in: https://github.com/Belodri/fvtt-terrain-mapper_fork/commit/53ae7b9ba94ee8982e65f00a41ac7182deaefd28

Fixes #272