### PR TITLE
Fix display issues of equipped triggered spell gems.

### DIFF
--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -20,3 +20,5 @@
     - Stocks
 - fixed synchronisation issues between existing settlements and the database
 - add: auto update spice list journal when snack pack is opened by Shalkoc
+- add: Toggleable display for equipped triggered spell gems with trigger condition.
+- change: Spellgems now track their spell slot level (and trigger condition if they are triggered) in a flag (spellgems created before this patch do not track their spell slot)

--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -20,5 +20,5 @@
     - Stocks
 - fixed synchronisation issues between existing settlements and the database
 - add: auto update spice list journal when snack pack is opened by Shalkoc
-- add: Toggleable display for equipped triggered spell gems with trigger condition.
+- add: Toggleable display for equipped triggered spell gems with trigger condition. For Non-GM users, only spell gems equipped by their character are displayed. 
 - change: Spellgems now track their spell slot level (and trigger condition if they are triggered) in a flag (spellgems created before this patch do not track their spell slot)

--- a/features/professions/spellscribing/SpellGem.mjs
+++ b/features/professions/spellscribing/SpellGem.mjs
@@ -33,12 +33,13 @@ export async function createSpellGem(actor, chosenArgs) {
 function getChanges(actor, chosenArgs) {
     const rollData = actor.getRollData();
 
-    //get spell level level for name (0th, 1st, 2nd,...9th)
+    //get spell level level for name (Cantrip, 1st, 2nd,...9th)
     const titleSpellLevelString = 
-        chosenArgs.selectedSpellSlotLevel === 1 ? " - 1st" :
-            chosenArgs.selectedSpellSlotLevel === 2 ? " - 2nd" :
-                chosenArgs.selectedSpellSlotLevel === 3 ? " - 3rd" :
-                    ` - ${chosenArgs.selectedSpellSlotLevel}th`;
+        chosenArgs.selectedSpellSlotLevel === 0 ? " - Cantrip" :
+            chosenArgs.selectedSpellSlotLevel === 1 ? " - 1st" :
+                chosenArgs.selectedSpellSlotLevel === 2 ? " - 2nd" :
+                    chosenArgs.selectedSpellSlotLevel === 3 ? " - 3rd" :
+                        ` - ${chosenArgs.selectedSpellSlotLevel}th`;
 
     //general changes first
     const name = chosenArgs.isTrigger ? `Triggered: ${chosenArgs.chosenSpell.name}${titleSpellLevelString}` : `Activated: ${chosenArgs.chosenSpell.name}${titleSpellLevelString}`;
@@ -52,6 +53,8 @@ function getChanges(actor, chosenArgs) {
         "system.price.value": chosenArgs.chosenGem.system.price.value,
         "system.weight.value": chosenArgs.chosenGem.system.weight.value,
         "flags.talia-custom.spellGem.school": chosenArgs.chosenSpell.system.school,
+        "flags.talia-custom.spellGem.spellLevel": chosenArgs.selectedSpellSlotLevel,
+        "flags.talia-custom.spellGem.triggerCondition": chosenArgs.triggerConditions ?? undefined,
     };
 
     //attack changes


### PR DESCRIPTION
- add: Toggleable display for equipped triggered spell gems with trigger condition. For Non-GM users, only spell gems equipped by their character are displayed. 
- change: Spellgems now track their spell slot level (and trigger condition if they are triggered) in a flag (spellgems created before this patch do not track their spell slot)

Fixes #281