### PR TITLE
Add toggleable GM occlusion feature and fix typo

### DIFF
--- a/changelog_draft.md
+++ b/changelog_draft.md
@@ -23,3 +23,4 @@
 - add: Toggleable display for equipped triggered spell gems with trigger condition. For Non-GM users, only spell gems equipped by their character are displayed. 
 - change: Spellgems now track their spell slot level (and trigger condition if they are triggered) in a flag (spellgems created before this patch do not track their spell slot)
 - add: Proper implementation of GuildManager
+- add: Allow gm clients to ignore tile occlusion. Toggleable in Tile config ui.

--- a/utils/_utils.mjs
+++ b/utils/_utils.mjs
@@ -11,6 +11,7 @@ import TaliaDate from "./TaliaDate.mjs";
 import RepeatingEffects from "./RepeatingEffects.mjs";
 import triggeredSpellGemsDisplay from "./triggeredSpellGemsDisplay.mjs";
 import DetectionChecker from "./detectionChecker.mjs";
+import overrideTileOcclusion from "./overrideTileOcclusion.mjs";
 
 export const TaliaUtils = {
     Helpers,
@@ -30,6 +31,7 @@ export default {
         sceneEffects.register();
         RepeatingEffects.register();
         triggeredSpellGemsDisplay.register();
+        overrideTileOcclusion.register();
 
         TaliaCustomAPI.add(TaliaUtils, "none");
     }

--- a/utils/overrideTileOcclusion.mjs
+++ b/utils/overrideTileOcclusion.mjs
@@ -1,0 +1,44 @@
+import { MODULE } from "../scripts/constants.mjs";
+
+export default {
+    register() {
+        renderTileConfigHook();
+    }
+}
+
+/**
+ * The logic for this is in a wrapper on Tile.prototype._refreshMesh
+ */
+function renderTileConfigHook() {
+    Hooks.on("renderTileConfig", onRenderTileConfigHook)
+
+    /**
+     * 
+     * @param {TileConfig} app 
+     * @param {JQuery} html 
+     * @param {object} data 
+     */
+    function onRenderTileConfigHook(app, html, data) {
+
+        const { BooleanField } = foundry.data.fields;
+        const enableGmIgnoreOcclusionField = new BooleanField({
+            label: "Gm Ignore Occlusion", 
+            hint: "When set this tile is rendered invisible for GMs, no matter their occlusion state."
+        }).toFormGroup({},{
+            name: `flags.${MODULE.ID}.gmIgnoreOcclusion`,
+            value: data.document.flags?.[MODULE.ID]?.gmIgnoreOcclusion ?? false
+        }).outerHTML;
+        
+
+        const div = document.createElement("div");
+        div.innerHTML = enableGmIgnoreOcclusionField;
+
+        const overheadTab = html.find(`.tab[data-tab="overhead"]`)[0];
+        if(!overheadTab) return;
+
+        overheadTab.appendChild(div);
+        app.setPosition({height: "auto"});
+    }
+}
+
+

--- a/utils/sceneEffects.mjs
+++ b/utils/sceneEffects.mjs
@@ -40,7 +40,7 @@ class SceneEffectManager {
     /**
      * Hook renderSceneConfig; adds a field to add effects via the gui.
      * @param {Application} app             The Application instance being rendered
-     * @param {jQuery} html                 The inner HTML of the document that will be displayed and may be modified
+     * @param {JQuery} html                 The inner HTML of the document that will be displayed and may be modified
      * @param {object} data                 The object of data used when rendering the application
      */
     static renderSceneConfigHook(app, html, data) {

--- a/wrappers/_wrappers.mjs
+++ b/wrappers/_wrappers.mjs
@@ -14,6 +14,7 @@ export function registerWrappers() {
     restrictMovement.registerWrapper();
     getRollDataWrapper.registerWrapper();
     libWrapper.register(MODULE.ID, "Actor.prototype.toggleStatusEffect", wrap_Actor_prototype_toggleStatusEffect, "OVERRIDE");
+    libWrapper.register(MODULE.ID, "Tile.prototype._refreshMesh", wrap_Tile_prototype__refreshMesh, "WRAPPER");
 }
 
 /** Lets other parts of the module hook into talia_addToRollData and mutate the taliaObj which is then appended to rollData */
@@ -227,4 +228,19 @@ async function wrap_Actor_prototype_toggleStatusEffect(statusId, {active, overla
     if ( overlay ) effect.updateSource({"flags.core.overlay": true});
     if ( chosenDuration ) effect.updateSource({"duration.seconds": chosenDuration});    //added line
     return ActiveEffect.implementation.create(effect, {parent: this, keepId: true});
+}
+
+/**
+ * If the flag is set, the tile is rendered invisible for gms only.
+ * @this {Tile}
+ */
+function wrap_Tile_prototype__refreshMesh(wrapped, ...args) {
+    const ret = wrapped(...args);
+    if(game.user.isGM 
+        && this.mesh
+        && this.document.flags?.[MODULE.ID]?.gmIgnoreOcclusion
+    ) {
+        this.mesh.unoccludedAlpha = 0;
+    }
+    return ret;
 }


### PR DESCRIPTION
- add: Allow gm clients to ignore tile occlusion. Toggleable in Tile config ui.

- correct a typo in the scene effect documentation.