### PR TITLE
Rename and refactor damage or heal functionality

### DIFF
--- a/macros/_macros.mjs
+++ b/macros/_macros.mjs
@@ -1,0 +1,7 @@
+import damageOrHealControlled from "../macros/damageOrHealControlled.mjs";
+
+export default {
+    registerSection() {
+        damageOrHealControlled.register();
+    }
+}

--- a/macros/damageOrHealControlled.mjs
+++ b/macros/damageOrHealControlled.mjs
@@ -2,11 +2,14 @@ import { TaliaCustomAPI } from "../scripts/api.mjs";
 
 export default {
     register() {
-        TaliaCustomAPI.add({damageOrHealSelf}, "Macros");
+        TaliaCustomAPI.add({
+            damageOrHealSelf: damageOrHealControlled, // Old function name, keep for compatability with older macros
+            damageOrHealControlled
+        }, "Macros"); 
     }
 }
 
-async function damageOrHealSelf() {
+async function damageOrHealControlled() {
     const types = {
         untyped: { label: "Untyped" },
         ...CONFIG.DND5E.damageTypes,
@@ -31,8 +34,8 @@ async function damageOrHealSelf() {
         speaker: { alias: game.user.name },
         flavor: `<b>Type:</b> ${types[chosen.type].label}`
     });
-    await game.dice3d.waitFor3DAnimationByMessageID(msg.id);
-
+    if(!roll.isDeterministic) await game.dice3d.waitFor3DAnimationByMessageID(msg.id);
+    
     const func = chosen.type === "temphp"
         ? { name: "applyTempHP", arg: roll.total }
         : { name: "applyDamage", arg: [{ value: roll.total, type: chosen.type === "untyped" ? undefined : chosen.type }] };
@@ -74,7 +77,7 @@ async function dialog(types, priorChosen = {}) {
         },
         content: span + typeField + formulaField,
         rejectClose: false,
-        modal: true,
+        modal: false,
         ok: {
             callback: (event, button) => new FormDataExtended(button.form).object
         }

--- a/scripts/module.mjs
+++ b/scripts/module.mjs
@@ -7,6 +7,7 @@ import _gmMacros from "../gmMacros/_gmMacros.mjs";
 import _items from "../items/_items.mjs";
 import _spells from "../spells/_spells.mjs";
 import _features from "../features/_features.mjs";
+import _macros from "../macros/_macros.mjs";
 
 /*
     API looks like this:
@@ -62,6 +63,7 @@ Hooks.once("init", () => {
     _items.registerSection();
     _spells.registerSection();
     _features.registerSection();
+    _macros.registerSection();
     registerRulePages();
 });
 

--- a/utils/_utils.mjs
+++ b/utils/_utils.mjs
@@ -14,7 +14,6 @@ import DetectionChecker from "./detectionChecker.mjs";
 import overrideTileOcclusion from "./overrideTileOcclusion.mjs";
 import ExtendedRest from "./ExtendedRest.mjs";
 import RepeatAttackManager from "./RepeatAttackManager.mjs";
-import damageOrHealSelfDialog from "./damageOrHealSelfDialog.mjs";
 
 export const TaliaUtils = {
     Helpers,
@@ -37,7 +36,6 @@ export default {
         overrideTileOcclusion.register();
         ExtendedRest.register();
         RepeatAttackManager.register();
-        damageOrHealSelfDialog.register();
 
         TaliaCustomAPI.add(TaliaUtils, "none");
     }


### PR DESCRIPTION
Rename and refactor the damage or heal functionality for improved clarity and organization. Move the logic to a new macros directory and ensure compatibility with older, existing macros.