### PR TITLE
Fix twinned metamagic and cantrip cost handling

### DIFF
--- a/features/character/naami/metamagic.mjs
+++ b/features/character/naami/metamagic.mjs
@@ -51,10 +51,12 @@ function twinned(itemName = "Metamagic: Twinned Spell") {
 
         (async() => {
             const sorcPoints = await chooseSpellLevel(item);
-            if(sorcPoints) {
-                await item.update({"system.consume.amount": sorcPoints});
-                item.use({}, {skipItemMacro: true});
-            }
+            if(sorcPoints === null) return;
+
+            // ensure that cantrips also consume 1 sorc point
+            const points = Math.max(1, sorcPoints);
+            await item.update({"system.consume.amount": points});
+            item.use({}, {skipItemMacro: true});
         })();
         return false;
     });

--- a/features/character/naami/metamagic.mjs
+++ b/features/character/naami/metamagic.mjs
@@ -50,9 +50,11 @@ function twinned(itemName = "Metamagic: Twinned Spell") {
         if(item.name !== itemName || options.skipItemMacro ) return;
 
         (async() => {
-            const sorcPoints = await chooseSpellLevel(item) ?? 0;
-            await item.update({"system.consume.amount": sorcPoints});
-            item.use({}, {skipItemMacro: true});
+            const sorcPoints = await chooseSpellLevel(item);
+            if(sorcPoints) {
+                await item.update({"system.consume.amount": sorcPoints});
+                item.use({}, {skipItemMacro: true});
+            }
         })();
         return false;
     });


### PR DESCRIPTION
Ensure that the `chooseSpellLevel` dialog does not update if cancelled and enforce a minimum cost for cantrips.