### PR TITLE
Fix statusEnricherDialog origin UUID retrieval

### DIFF
--- a/utils/utilHooks.mjs
+++ b/utils/utilHooks.mjs
@@ -308,7 +308,7 @@ function registerStatusToggleEnricherDialog() {
      * @returns {Promise<void>}
      */
     async function configDialogAndApply(statusId, event) {
-        const origin = getOriginItemUuid(event);
+        const origin = getOriginUuid(event);
         const content = getBaseDialogContent() + getDaeContent(!!origin);
         const statusName = CONFIG.statusEffects.find(e => e.id === statusId)?.name;
 


### PR DESCRIPTION
Correct the function to retrieve the origin UUID in the status enricher dialog configuration.