### PR TITLE
Fix optional chaining in onRenderTidy5eActorSheet method

### DIFF
--- a/utils/currencyChatLogger.mjs
+++ b/utils/currencyChatLogger.mjs
@@ -67,11 +67,11 @@ class Logger {
      * @param {object} data 
      */
     static onRenderTidy5eActorSheet(app, element, data) {
-        if(!app.options.classes.includes("tidy5e-sheet") 
+        if(!app?.options?.classes?.includes?.("tidy5e-sheet") 
             || !game.settings.get(MODULE.ID, Logger.CONFIG.settings.displayActorSheetToggle)
         ) return;
 
-        const currencyEle = element.querySelector(".currency");
+        const currencyEle = element?.querySelector?.(".currency");
         if(!currencyEle) return;
 
         const actor = data.actor;


### PR DESCRIPTION
Improve code safety by implementing optional chaining in the CurrencyChatLogger.onRenderTidy5eActorSheet method.