### PR TITLE
Rename ExtendedRest to Resting and add test override functionality

### DIFF
--- a/utils/Resting.mjs
+++ b/utils/Resting.mjs
@@ -1,8 +1,24 @@
 export default {
     register() {
         ExtendedRest.init();
+        grittyLiteTestOverride();
     }
 }
+
+/** 
+ * Overrides the rest types defined in the config while we're testing this variation of the gritty rest rules. 
+ * Does not impact normal rest rules so switching back and forth is easy via the settings.
+ */
+function grittyLiteTestOverride() {
+    // Durations are in minutes!!
+    const overrides = {
+        "long.duration.gritty": 60 * 24,
+        "extended.duration.gritty": 60 * 24 * 30
+    };
+
+    foundry.utils.mergeObject(CONFIG.DND5E.restTypes, foundry.utils.expandObject(overrides));
+}
+
 
 /**
  * Results from a rest operation.

--- a/utils/_utils.mjs
+++ b/utils/_utils.mjs
@@ -12,7 +12,7 @@ import RepeatingEffects from "./RepeatingEffects.mjs";
 import triggeredSpellGemsDisplay from "./triggeredSpellGemsDisplay.mjs";
 import DetectionChecker from "./detectionChecker.mjs";
 import overrideTileOcclusion from "./overrideTileOcclusion.mjs";
-import ExtendedRest from "./ExtendedRest.mjs";
+import Resting from "./Resting.mjs";
 import MultiattackManager from "./MultiattackManager.mjs";
 import currencyChatLogger from "./currencyChatLogger.mjs";
 import CombatTriggers from "./CombatTriggers.mjs";
@@ -38,7 +38,7 @@ export default {
         RepeatingEffects.init();
         triggeredSpellGemsDisplay.register();
         overrideTileOcclusion.register();
-        ExtendedRest.register();
+        Resting.register();
         MultiattackManager.register();
         currencyChatLogger.register();
         multiroll.register();


### PR DESCRIPTION
Rename the ExtendedRest module to Resting and introduce a gritty-lite test override to easily test variations of the gritty rest rules.