### PR TITLE
Change exotic currency type to consumable

### DIFF
--- a/items/otherItemCategories.mjs
+++ b/items/otherItemCategories.mjs
@@ -1,15 +1,15 @@
 export default {
     register() {
-        registerLootCategories();
+        registerCategories();
     }
 }
 
 /**
  *
  */
-function registerLootCategories() {
+function registerCategories() {
     CONFIG.DND5E.lootTypes.livestock = {label: "Livestock"};
     CONFIG.DND5E.lootTypes.wood = {label: "Logs and Lumber"};
     CONFIG.DND5E.lootTypes.stone = {label: "Stone"};
-    CONFIG.DND5E.lootTypes.exoticCurrency = {label: "Exotic Currency"};
+    CONFIG.DND5E.consumableTypes.exoticCurrency = {label: "Exotic Currency"}
 }


### PR DESCRIPTION
Update the registration of exotic currency to be categorized under consumable types instead of loot types.